### PR TITLE
Add UIKit import to generated file

### DIFF
--- a/R.swift/func.swift
+++ b/R.swift/func.swift
@@ -139,6 +139,10 @@ func writeResourceFile(code: String, toFolderURL folderURL: NSURL) {
 
 // MARK: Code generator functions
 
+func swiftImports() -> String {
+    return "import UIKit"
+}
+
 func swiftImageStructWithAssetFolders(assetFolders: [AssetFolder]) -> String {
   return distinct(assetFolders.flatMap { $0.imageAssets })
     .reduce("struct image {\n") {

--- a/R.swift/main.swift
+++ b/R.swift/main.swift
@@ -15,6 +15,9 @@ let findAllStoryboardURLsInDirectory = filterDirectoryContentsRecursively(defaul
 
 inputDirectories(NSProcessInfo.processInfo())
   .each { directory in
+    // Imports
+    let imports = swiftImports()
+    
     // Storyboards
     let storyboards = findAllStoryboardURLsInDirectory(url: directory)
       .map { Storyboard(url: $0) }
@@ -37,6 +40,6 @@ inputDirectories(NSProcessInfo.processInfo())
 
     // Write out the code
     let code = [imageStruct, segueStruct, storyboardStructs, validateAllStoryboardsFunction]
-      .reduce("struct R {") { $0 + "\n" + indent(string: $1) } + "}\n"
+      .reduce("\(imports)\n\nstruct R {") { $0 + "\n" + indent(string: $1) } + "}\n"
     writeResourceFile(code, toFolderURL: directory)
   }


### PR DESCRIPTION
After following the installation instructions I encountered build errors informing me that `UIImage` and `UIStoryboard` were unknown types. I've update the code generator to include an import of `UIKit` to resolve these errors.

Now, I would imagine this issue would have come up earlier if it's affecting everyone - so maybe I missed something that would have resolved this without code changes.

Also, I thought I should inform you that the idea behind this project is genius - I thought that I would always have to deal with storyboards/images as strings, I didn't know there was a better way until now, and I love the better way! Thank you!