### PR TITLE
Better reuse identifiers

### DIFF
--- a/R.swift/func.swift
+++ b/R.swift/func.swift
@@ -135,7 +135,7 @@ func storyboardStructForStoryboard(storyboard: Storyboard) -> Struct {
     })
   let validateViewControllersFunc = Function(isStatic: true, name: "validateViewControllers", parameters: [], returnType: Type._Void, body: join("\n", validateViewControllersLines))
 
-  return Struct(type: Type(name: storyboard.name), lets: [], vars: instanceVars + initialViewControllerVar + viewControllerVars, functions: [validateImagesFunc, validateViewControllersFunc], structs: [])
+  return Struct(type: Type(name: sanitizedSwiftName(storyboard.name)), lets: [], vars: instanceVars + initialViewControllerVar + viewControllerVars, functions: [validateImagesFunc, validateViewControllersFunc], structs: [])
 }
 
 // Nib

--- a/R.swift/func.swift
+++ b/R.swift/func.swift
@@ -166,8 +166,8 @@ func reuseIdentifierStructFromReusables(reusables: [Reusable]) -> Struct {
       Var(
         isStatic: true,
         name: $0.identifier,
-        type: ReusableStruct.type.withGenericType($0.type),
-        getter: "return \(ReusableStruct.type.name)(\"\($0.identifier)\")"
+        type: ReuseIdentifier.type.withGenericType($0.type),
+        getter: "return \(ReuseIdentifier.type.name)(\"\($0.identifier)\")"
       )
     }
 

--- a/R.swift/func.swift
+++ b/R.swift/func.swift
@@ -160,10 +160,9 @@ func nibStructForNib(nib: Nib) -> Struct {
 
 // Reuse identifiers
 
-func reuseIdentifierStructFromReuseIdentifierContainers(containers: [ReuseIdentifierContainer]) -> Struct {
-  let reuseIdentifierVars = containers
-    .flatMap { $0.reuseIdentifiers }
-    .map { Var(name: $0, type: Type._String, getter: "return \"\($0)\"") }
+func reuseIdentifierStructFromReusables(reusables: [Reusable]) -> Struct {
+  let reuseIdentifierVars = reusables
+    .map { Var(name: $0.identifier, type: Type(name: "ReuseIdentifier", genericType: $0.type, optional: false), getter: "return ReuseIdentifier(\"\($0.identifier)\")") }
 
   return Struct(name: "reuseIdentifier", vars: reuseIdentifierVars, functions: [], structs: [])
 }

--- a/R.swift/func.swift
+++ b/R.swift/func.swift
@@ -155,7 +155,7 @@ func nibStructForNib(nib: Nib) -> Struct {
     .map { (view: $0.0, ordinal: $0.1) }
     .map { Function(name: "\($0.ordinal.word)View", parameters: [ownerOrNilParameter, optionsOrNilParameter], returnType: $0.view.asOptional(), body: "return instantiateWithOwner(ownerOrNil, options: optionsOrNil)[\($0.ordinal.number - 1)] as? \($0.view)") }
 
-  return Struct(type: Type(name: nib.name), lets: [], vars: instanceVars, functions: [instantiateFunc] + viewFuncs, structs: [])
+  return Struct(type: Type(name: sanitizedSwiftName(nib.name)), lets: [], vars: instanceVars, functions: [instantiateFunc] + viewFuncs, structs: [])
 }
 
 // Reuse identifiers
@@ -167,7 +167,7 @@ func reuseIdentifierStructFromReusables(reusables: [Reusable]) -> Struct {
         isStatic: true,
         name: $0.identifier,
         type: ReuseIdentifier.type.withGenericType($0.type),
-        getter: "return \(ReuseIdentifier.type.name)(\"\($0.identifier)\")"
+        getter: "return \(ReuseIdentifier.type.name)(identifier: \"\($0.identifier)\")"
       )
     }
 

--- a/R.swift/func.swift
+++ b/R.swift/func.swift
@@ -141,37 +141,55 @@ func storyboardStructForStoryboard(storyboard: Storyboard) -> Struct {
 // Nib
 
 func nibStructFromNibs(nibs: [Nib]) -> Struct {
-  return Struct(type: Type(name: "nib"), lets: [], vars: [], functions: [], structs: nibs.map(nibStructForNib))
+  return Struct(type: Type(name: "nib"), lets: [], vars: nibs.map(nibVarForNib), functions: [], structs: nibs.map(nibStructForNib))
+}
+
+func nibVarForNib(nib: Nib) -> Var {
+  let structType = Type(name: nib.name)
+  return Var(isStatic: true, name: nib.name, type: structType, getter: "return \(structType)()")
 }
 
 func nibStructForNib(nib: Nib) -> Struct {
   let ownerOrNilParameter = Function.Parameter(name: "ownerOrNil", type: Type._AnyObject.asOptional())
   let optionsOrNilParameter = Function.Parameter(name: "options", localName: "optionsOrNil", type: Type(name: "[NSObject : AnyObject]", optional: true))
 
-  let instanceVars = [Var(isStatic: true, name: "instance", type: Type._UINib, getter: "return UINib.init(nibName: \"\(nib.name)\", bundle: nil)")]
-  let instantiateFunc = Function(isStatic: true, name: "instantiateWithOwner", parameters: [ownerOrNilParameter, optionsOrNilParameter], returnType: Type(name: "[AnyObject]"), body: "return instance.instantiateWithOwner(ownerOrNil, options: optionsOrNil)")
+  let instanceVars = [Var(isStatic: false, name: "instance", type: Type._UINib, getter: "return UINib.init(nibName: \"\(nib.name)\", bundle: nil)")]
+  let instantiateFunc = Function(isStatic: false, name: "instantiateWithOwner", parameters: [ownerOrNilParameter, optionsOrNilParameter], returnType: Type(name: "[AnyObject]"), body: "return instance.instantiateWithOwner(ownerOrNil, options: optionsOrNil)")
 
   let viewFuncs = zip(nib.rootViews, Ordinals)
     .map { (view: $0.0, ordinal: $0.1) }
-    .map { Function(isStatic: true, name: "\($0.ordinal.word)View", parameters: [ownerOrNilParameter, optionsOrNilParameter], returnType: $0.view.asOptional(), body: "return instantiateWithOwner(ownerOrNil, options: optionsOrNil)[\($0.ordinal.number - 1)] as? \($0.view)") }
+    .map { Function(isStatic: false, name: "\($0.ordinal.word)View", parameters: [ownerOrNilParameter, optionsOrNilParameter], returnType: $0.view.asOptional(), body: "return instantiateWithOwner(ownerOrNil, options: optionsOrNil)[\($0.ordinal.number - 1)] as? \($0.view)") }
 
-  return Struct(type: Type(name: sanitizedSwiftName(nib.name)), lets: [], vars: instanceVars, functions: [instantiateFunc] + viewFuncs, structs: [])
+  // TODO: Refactor, ugly code :(
+  let reuseIdentifierVars: [Var]
+  let reuseProtocols: [Type]
+  if let reusable = nib.reusables.first where nib.rootViews.count == 1 && nib.reusables.count == 1 {
+    let reusableVar = varFromReusable(reusable)
+    reuseIdentifierVars = [Var(isStatic: false, name: "reuseIdentifier", type: reusableVar.type, getter: reusableVar.getter)]
+    reuseProtocols = [ReusableProtocol.type]
+  } else {
+    reuseIdentifierVars = []
+    reuseProtocols = []
+  }
+
+  return Struct(type: Type(name: sanitizedSwiftName(nib.name, lowercaseFirstCharacter: false)), implements: [NibResourceProtocol.type] + reuseProtocols, lets: [], vars: instanceVars + reuseIdentifierVars, functions: [instantiateFunc] + viewFuncs, structs: [])
 }
 
 // Reuse identifiers
 
 func reuseIdentifierStructFromReusables(reusables: [Reusable]) -> Struct {
-  let reuseIdentifierVars = reusables
-    .map {
-      Var(
-        isStatic: true,
-        name: $0.identifier,
-        type: ReuseIdentifier.type.withGenericType($0.type),
-        getter: "return \(ReuseIdentifier.type.name)(identifier: \"\($0.identifier)\")"
-      )
-    }
+  let reuseIdentifierVars = reusables.map(varFromReusable)
 
   return Struct(type: Type(name: "reuseIdentifier"), lets: [], vars: reuseIdentifierVars, functions: [], structs: [])
+}
+
+func varFromReusable(reusable: Reusable) -> Var {
+  return Var(
+    isStatic: true,
+    name: reusable.identifier,
+    type: ReuseIdentifier.type.withGenericType(reusable.type),
+    getter: "return \(ReuseIdentifier.type.name)(identifier: \"\(reusable.identifier)\")"
+  )
 }
 
 // Validation

--- a/R.swift/main.swift
+++ b/R.swift/main.swift
@@ -38,7 +38,6 @@ inputDirectories(NSProcessInfo.processInfo())
 
     // Generate
     let structs = [
-      ReuseIdentifier,
       imageStructFromAssetFolders(assetFolders),
       segueStructFromStoryboards(storyboards),
       storyboardStructFromStoryboards(storyboards),
@@ -58,7 +57,13 @@ inputDirectories(NSProcessInfo.processInfo())
       functions: functions,
       structs: structs
     )
-    let fileContents = join("\n", [Header, "", Imports, "", resourceStruct.description])
+    let fileContents = join("\n", [
+      Header, "",
+      Imports, "",
+      resourceStruct.description, "",
+      ReuseIdentifier.description, "",
+      ReuseIdentifierUITableViewExtension.description
+    ])
 
     // Write file if we have changes
     if readResourceFile(directory) != fileContents {

--- a/R.swift/main.swift
+++ b/R.swift/main.swift
@@ -62,6 +62,8 @@ inputDirectories(NSProcessInfo.processInfo())
       Imports, "",
       resourceStruct.description, "",
       ReuseIdentifier.description, "",
+      NibResourceProtocol.description, "",
+      ReusableProtocol.description, "",
       ReuseIdentifierUITableViewExtension.description, "",
       ReuseIdentifierUICollectionViewExtension.description,
     ])

--- a/R.swift/main.swift
+++ b/R.swift/main.swift
@@ -33,7 +33,8 @@ inputDirectories(NSProcessInfo.processInfo())
     let nibs = findAllNibURLsInDirectory(url: directory)
       .map { Nib(url: $0) }
 
-    let reuseIdentifierContainers = nibs.map { $0 as ReuseIdentifierContainer } + storyboards.map { $0 as ReuseIdentifierContainer }
+    let reusables = (nibs.map { $0 as ReusableContainer } + storyboards.map { $0 as ReusableContainer })
+      .flatMap { $0.reusables }
 
     // Generate
     let structs = [
@@ -41,7 +42,7 @@ inputDirectories(NSProcessInfo.processInfo())
       segueStructFromStoryboards(storyboards),
       storyboardStructFromStoryboards(storyboards),
       nibStructFromNibs(nibs),
-      reuseIdentifierStructFromReuseIdentifierContainers(reuseIdentifierContainers)
+      reuseIdentifierStructFromReusables(reusables)
     ]
 
     let functions = [

--- a/R.swift/main.swift
+++ b/R.swift/main.swift
@@ -38,7 +38,7 @@ inputDirectories(NSProcessInfo.processInfo())
 
     // Generate
     let structs = [
-      ReusableStruct,
+      ReuseIdentifier,
       imageStructFromAssetFolders(assetFolders),
       segueStructFromStoryboards(storyboards),
       storyboardStructFromStoryboards(storyboards),

--- a/R.swift/main.swift
+++ b/R.swift/main.swift
@@ -38,11 +38,12 @@ inputDirectories(NSProcessInfo.processInfo())
 
     // Generate
     let structs = [
+      ReusableStruct,
       imageStructFromAssetFolders(assetFolders),
       segueStructFromStoryboards(storyboards),
       storyboardStructFromStoryboards(storyboards),
       nibStructFromNibs(nibs),
-      reuseIdentifierStructFromReusables(reusables)
+      reuseIdentifierStructFromReusables(reusables),
     ]
 
     let functions = [
@@ -50,7 +51,13 @@ inputDirectories(NSProcessInfo.processInfo())
     ]
 
     // Generate resource file contents
-    let resourceStruct = Struct(name: "R", vars: [], functions: functions, structs: structs, lowercaseFirstCharacter: false)
+    let resourceStruct = Struct(
+      type: Type(name: "R"),
+      lets: [],
+      vars: [],
+      functions: functions,
+      structs: structs
+    )
     let fileContents = join("\n", [Header, "", Imports, "", resourceStruct.description])
 
     // Write file if we have changes

--- a/R.swift/main.swift
+++ b/R.swift/main.swift
@@ -62,7 +62,8 @@ inputDirectories(NSProcessInfo.processInfo())
       Imports, "",
       resourceStruct.description, "",
       ReuseIdentifier.description, "",
-      ReuseIdentifierUITableViewExtension.description
+      ReuseIdentifierUITableViewExtension.description, "",
+      ReuseIdentifierUICollectionViewExtension.description,
     ])
 
     // Write file if we have changes

--- a/R.swift/types.swift
+++ b/R.swift/types.swift
@@ -34,6 +34,8 @@ struct Type: Printable, Equatable {
   static let _UINib = Type(name: "UINib")
   static let _UIView = Type(name: "UIView")
   static let _UIImage = Type(name: "UIImage")
+  static let _NSIndexPath = Type(name: "NSIndexPath")
+  static let _UITableView = Type(name: "UITableView")
   static let _UIStoryboard = Type(name: "UIStoryboard")
   static let _UIViewController = Type(name: "UIViewController")
 
@@ -160,6 +162,19 @@ struct Function: Printable {
   }
 }
 
+struct Extension: Printable {
+  let type: Type
+  let functions: [Function]
+
+  var description: String {
+    let functionsString = join("\n\n", functions.sorted { sanitizedSwiftName($0.name) < sanitizedSwiftName($1.name) })
+
+    let bodyComponents = [functionsString].filter { $0 != "" }
+    let bodyString = indent(join("\n\n", bodyComponents))
+    return "extension \(type) {\n\(bodyString)\n}"
+  }
+}
+
 struct Struct: Printable {
   let type: Type
   let implements: [Type]
@@ -192,7 +207,7 @@ struct Struct: Printable {
     let letsString = join("\n", lets.sorted { sanitizedSwiftName($0.name) < sanitizedSwiftName($1.name) })
     let varsString = join("\n", vars.sorted { sanitizedSwiftName($0.name) < sanitizedSwiftName($1.name) })
     let functionsString = join("\n\n", functions.sorted { sanitizedSwiftName($0.name) < sanitizedSwiftName($1.name) })
-    let structsString = join("\n\n", structs.sorted { sanitizedSwiftName($0.type.name) < sanitizedSwiftName($1.type.name) })
+    let structsString = join("\n\n", structs.sorted { $0.type.description < $1.type.description })
 
     let bodyComponents = [letsString, varsString, functionsString, structsString].filter { $0 != "" }
     let bodyString = indent(join("\n\n", bodyComponents))

--- a/R.swift/types.swift
+++ b/R.swift/types.swift
@@ -143,9 +143,12 @@ struct Function: Printable {
   let returnType: Type
   let body: String
 
+  var swiftName: String {
+    return sanitizedSwiftName(name, lowercaseFirstCharacter: true)
+  }
+
   var description: String {
     let staticString = isStatic ? "static " : ""
-    let swiftName = sanitizedSwiftName(name, lowercaseFirstCharacter: true)
     let parameterString = join(", ", parameters)
     let returnString = Type._Void == returnType ? "" : " -> \(returnType)"
     return "\(staticString)func \(swiftName)(\(parameterString))\(returnString) {\n\(indent(body))\n}"
@@ -156,14 +159,12 @@ struct Function: Printable {
     let localName: String?
     let type: Type
 
+    var swiftName: String {
+      return sanitizedSwiftName(name, lowercaseFirstCharacter: true)
+    }
+
     var description: String {
-      let swiftName = sanitizedSwiftName(name, lowercaseFirstCharacter: true)
-
-      if let localName = localName {
-        return "\(swiftName) \(localName): \(type)"
-      }
-
-      return "\(swiftName): \(type)"
+      return localName.map({ "\(self.swiftName) \($0): \(type)" }) ?? "\(swiftName): \(type)"
     }
 
     init(name: String, type: Type) {

--- a/R.swift/types.swift
+++ b/R.swift/types.swift
@@ -121,16 +121,18 @@ struct Let: Printable {
 }
 
 struct Function: Printable {
+  let isStatic: Bool
   let name: String
   let parameters: [Parameter]
   let returnType: Type
   let body: String
 
   var description: String {
+    let staticString = isStatic ? "static " : ""
     let swiftName = sanitizedSwiftName(name, lowercaseFirstCharacter: true)
     let parameterString = join(", ", parameters)
     let returnString = Type._Void == returnType ? "" : " -> \(returnType)"
-    return "static func \(swiftName)(\(parameterString))\(returnString) {\n\(indent(body))\n}"
+    return "\(staticString)func \(swiftName)(\(parameterString))\(returnString) {\n\(indent(body))\n}"
   }
 
   struct Parameter: Printable {

--- a/R.swift/types.swift
+++ b/R.swift/types.swift
@@ -36,8 +36,12 @@ struct Type: Printable, Equatable {
   static let _UIImage = Type(name: "UIImage")
   static let _NSIndexPath = Type(name: "NSIndexPath")
   static let _UITableView = Type(name: "UITableView")
+  static let _UITableViewCell = Type(name: "UITableViewCell")
+  static let _UITableViewHeaderFooterView = Type(name: "UITableViewHeaderFooterView")
   static let _UIStoryboard = Type(name: "UIStoryboard")
   static let _UICollectionView = Type(name: "UICollectionView")
+  static let _UICollectionViewCell = Type(name: "UICollectionViewCell")
+  static let _UICollectionReusableView = Type(name: "UICollectionReusableView")
   static let _UIViewController = Type(name: "UIViewController")
 
   let module: String?
@@ -96,6 +100,17 @@ struct Type: Printable, Equatable {
 
 func ==(lhs: Type, rhs: Type) -> Bool {
   return (lhs.module == rhs.module && lhs.name == rhs.name && lhs.optional == rhs.optional)
+}
+
+struct Typealias: Printable {
+  let alias: Type
+  let type: Type?
+
+  var description: String {
+    let typeString = type.map { " = \($0)" } ?? ""
+
+    return "typealias \(alias)\(typeString)"
+  }
 }
 
 struct Var: Printable {
@@ -162,6 +177,21 @@ struct Function: Printable {
       self.localName = localName
       self.type = type
     }
+  }
+}
+
+struct Protocol: Printable {
+  let type: Type
+  let typealiasses: [Typealias]
+  let vars: [Var]
+
+  var description: String {
+    let typealiassesString = join("\n", typealiasses.sorted { sanitizedSwiftName($0.alias.fullyQualifiedName) < sanitizedSwiftName($1.alias.fullyQualifiedName) })
+    let varsString = join("\n", vars.sorted { sanitizedSwiftName($0.name) < sanitizedSwiftName($1.name) })
+
+    let bodyComponents = [typealiassesString, varsString].filter { $0 != "" }
+    let bodyString = indent(join("\n\n", bodyComponents))
+    return "protocol \(type) {\n\(bodyString)\n}"
   }
 }
 

--- a/R.swift/types.swift
+++ b/R.swift/types.swift
@@ -37,6 +37,7 @@ struct Type: Printable, Equatable {
   static let _NSIndexPath = Type(name: "NSIndexPath")
   static let _UITableView = Type(name: "UITableView")
   static let _UIStoryboard = Type(name: "UIStoryboard")
+  static let _UICollectionView = Type(name: "UICollectionView")
   static let _UIViewController = Type(name: "UIViewController")
 
   let module: String?

--- a/R.swift/values.swift
+++ b/R.swift/values.swift
@@ -42,6 +42,7 @@ let ReuseIdentifierUITableViewExtension = Extension(
   type: Type._UITableView,
   functions: [
     Function(
+      isStatic: false,
       name: "dequeueReusableCellWithIdentifier<T : UITableViewCell>",
       parameters: [
         Function.Parameter(name: "identifier", type: ReuseIdentifier.type),

--- a/R.swift/values.swift
+++ b/R.swift/values.swift
@@ -49,7 +49,23 @@ let ReuseIdentifierUITableViewExtension = Extension(
         Function.Parameter(name: "forIndexPath", localName: "indexPath", type: Type._NSIndexPath)
       ],
       returnType: Type(name: "T", genericType: nil, optional: true),
-      body: "return dequeueReusableCellWithIdentifier(identifier.value, forIndexPath: indexPath) as? T"
+      body: "return dequeueReusableCellWithIdentifier(identifier.identifier, forIndexPath: indexPath) as? T"
+    )
+  ]
+)
+
+let ReuseIdentifierUICollectionViewExtension = Extension(
+  type: Type._UICollectionView,
+  functions: [
+    Function(
+      isStatic: false,
+      name: "dequeueReusableCellWithReuseIdentifier<T : UICollectionViewCell>",
+      parameters: [
+        Function.Parameter(name: "identifier", type: ReuseIdentifier.type),
+        Function.Parameter(name: "forIndexPath", localName: "indexPath", type: Type._NSIndexPath)
+      ],
+      returnType: Type(name: "T", genericType: nil, optional: true),
+      body: "return dequeueReusableCellWithReuseIdentifier(identifier.identifier, forIndexPath: indexPath) as? T"
     )
   ]
 )

--- a/R.swift/values.swift
+++ b/R.swift/values.swift
@@ -18,8 +18,8 @@ let Imports = join("\n", [
   "import UIKit",
   ])
 
-let ReusableStruct = Struct(
-  type: Type(name: "Reusable", genericType: Type(name: "T")),
+let ReuseIdentifier = Struct(
+  type: Type(name: "ReuseIdentifier", genericType: Type(name: "T")),
   implements: [Type(name: "Printable")],
   lets: [
     Let(

--- a/R.swift/values.swift
+++ b/R.swift/values.swift
@@ -38,18 +38,76 @@ let ReuseIdentifier = Struct(
   functions: [],
   structs: [])
 
+let NibResourceProtocol = Protocol(
+  type: Type(name: "NibResource"),
+  typealiasses: [],
+  vars: [
+    Var(isStatic: false, name: "instance", type: Type._UINib, getter: "get")
+  ]
+)
+
+let ReusableProtocol = Protocol(
+  type: Type(name: "Reusable"),
+  typealiasses: [
+    Typealias(alias: Type(name: "T"), type: nil)
+  ],
+  vars: [
+    Var(isStatic: false, name: "reuseIdentifier", type: ReuseIdentifier.type, getter: "get")
+  ]
+)
+
 let ReuseIdentifierUITableViewExtension = Extension(
   type: Type._UITableView,
   functions: [
     Function(
       isStatic: false,
-      name: "dequeueReusableCellWithIdentifier<T : UITableViewCell>",
+      name: "dequeueReusableCellWithIdentifier<T : \(Type._UITableViewCell)>",
       parameters: [
         Function.Parameter(name: "identifier", type: ReuseIdentifier.type),
         Function.Parameter(name: "forIndexPath", localName: "indexPath", type: Type._NSIndexPath)
       ],
       returnType: Type(name: "T", genericType: nil, optional: true),
       body: "return dequeueReusableCellWithIdentifier(identifier.identifier, forIndexPath: indexPath) as? T"
+    ),
+
+    Function(
+      isStatic: false,
+      name: "dequeueReusableCellWithIdentifier<T : \(Type._UITableViewCell)>",
+      parameters: [
+        Function.Parameter(name: "identifier", type: ReuseIdentifier.type),
+      ],
+      returnType: Type(name: "T", genericType: nil, optional: true),
+      body: "return dequeueReusableCellWithIdentifier(identifier.identifier) as? T"
+    ),
+
+    Function(
+      isStatic: false,
+      name: "dequeueReusableHeaderFooterViewWithIdentifier<T : \(Type._UITableViewHeaderFooterView)>",
+      parameters: [
+        Function.Parameter(name: "identifier", type: ReuseIdentifier.type),
+      ],
+      returnType: Type(name: "T", genericType: nil, optional: true),
+      body: "return dequeueReusableHeaderFooterViewWithIdentifier(identifier.identifier) as? T"
+    ),
+
+    Function(
+      isStatic: false,
+      name: "registerNib<T: \(NibResourceProtocol.type) where T: \(ReusableProtocol.type), T.T: UITableViewCell>",
+      parameters: [
+        Function.Parameter(name: "nibResource", type: Type(name: "T"))
+      ],
+      returnType: Type._Void,
+      body: "registerNib(nibResource.instance, forCellReuseIdentifier: nibResource.reuseIdentifier.identifier)"
+    ),
+
+    Function(
+      isStatic: false,
+      name: "registerNibForHeaderFooterView<T: \(NibResourceProtocol.type) where T: \(ReusableProtocol.type), T.T: UIView>",
+      parameters: [
+        Function.Parameter(name: "nibResource", type: Type(name: "T"))
+      ],
+      returnType: Type._Void,
+      body: "registerNib(nibResource.instance, forHeaderFooterViewReuseIdentifier: nibResource.reuseIdentifier.identifier)"
     )
   ]
 )
@@ -59,13 +117,46 @@ let ReuseIdentifierUICollectionViewExtension = Extension(
   functions: [
     Function(
       isStatic: false,
-      name: "dequeueReusableCellWithReuseIdentifier<T : UICollectionViewCell>",
+      name: "dequeueReusableCellWithReuseIdentifier<T : \(Type._UICollectionViewCell)>",
       parameters: [
         Function.Parameter(name: "identifier", type: ReuseIdentifier.type),
         Function.Parameter(name: "forIndexPath", localName: "indexPath", type: Type._NSIndexPath)
       ],
       returnType: Type(name: "T", genericType: nil, optional: true),
       body: "return dequeueReusableCellWithReuseIdentifier(identifier.identifier, forIndexPath: indexPath) as? T"
+    ),
+
+    Function(
+      isStatic: false,
+      name: "dequeueReusableSupplementaryViewOfKind<T : \(Type._UICollectionReusableView)>",
+      parameters: [
+        Function.Parameter(name: "elementKind", type: Type._String),
+        Function.Parameter(name: "withReuseIdentifier", localName: "identifier", type: ReuseIdentifier.type),
+        Function.Parameter(name: "forIndexPath", localName: "indexPath", type: Type._NSIndexPath)
+      ],
+      returnType: Type(name: "T", genericType: nil, optional: true),
+      body: "return dequeueReusableSupplementaryViewOfKind(elementKind, withReuseIdentifier: identifier.identifier, forIndexPath: indexPath) as? T"
+    ),
+
+    Function(
+      isStatic: false,
+      name: "registerNib<T: \(NibResourceProtocol.type) where T: \(ReusableProtocol.type), T.T: UICollectionViewCell>",
+      parameters: [
+        Function.Parameter(name: "nibResource", type: Type(name: "T"))
+      ],
+      returnType: Type._Void,
+      body: "registerNib(nibResource.instance, forCellWithReuseIdentifier: nibResource.reuseIdentifier.identifier)"
+    ),
+
+    Function(
+      isStatic: false,
+      name: "registerNib<T: \(NibResourceProtocol.type) where T: \(ReusableProtocol.type), T.T: UICollectionReusableView>",
+      parameters: [
+        Function.Parameter(name: "nibResource", type: Type(name: "T")),
+        Function.Parameter(name: "forSupplementaryViewOfKind", localName: "kind", type: Type._String)
+      ],
+      returnType: Type._Void,
+      body: "registerNib(nibResource.instance, forSupplementaryViewOfKind: kind, withReuseIdentifier: nibResource.reuseIdentifier.identifier)"
     )
   ]
 )

--- a/R.swift/values.swift
+++ b/R.swift/values.swift
@@ -38,6 +38,21 @@ let ReuseIdentifier = Struct(
   functions: [],
   structs: [])
 
+let ReuseIdentifierUITableViewExtension = Extension(
+  type: Type._UITableView,
+  functions: [
+    Function(
+      name: "dequeueReusableCellWithIdentifier<T : UITableViewCell>",
+      parameters: [
+        Function.Parameter(name: "identifier", type: ReuseIdentifier.type),
+        Function.Parameter(name: "forIndexPath", localName: "indexPath", type: Type._NSIndexPath)
+      ],
+      returnType: Type(name: "T", genericType: nil, optional: true),
+      body: "return dequeueReusableCellWithIdentifier(identifier.value, forIndexPath: indexPath) as? T"
+    )
+  ]
+)
+
 let IndentationString = "  "
 
 let Ordinals = [

--- a/R.swift/values.swift
+++ b/R.swift/values.swift
@@ -45,8 +45,9 @@ let Ordinals = [
 
 let ElementNameToTypeMapping = [
   "viewController": Type._UIViewController,
-  "glkViewController": Type(name: "GLKViewController"),
+  "tableViewCell": Type(name: "UITableViewCell"),
   "tabBarController": Type(name: "UITabBarController"),
+  "glkViewController": Type(name: "GLKViewController"),
   "pageViewController": Type(name: "UIPageViewController"),
   "tableViewController": Type(name: "UITableViewController"),
   "splitViewController": Type(name: "UISplitViewController"),

--- a/R.swift/values.swift
+++ b/R.swift/values.swift
@@ -18,6 +18,26 @@ let Imports = join("\n", [
   "import UIKit",
   ])
 
+let ReusableStruct = Struct(
+  type: Type(name: "Reusable", genericType: Type(name: "T")),
+  implements: [Type(name: "Printable")],
+  lets: [
+    Let(
+      name: "identifier",
+      type: Type(name: "String")
+    )
+  ],
+  vars: [
+    Var(
+      isStatic: false,
+      name: "description",
+      type: Type(name: "String"),
+      getter: "return identifier"
+    )
+  ],
+  functions: [],
+  structs: [])
+
 let IndentationString = "  "
 
 let Ordinals = [


### PR DESCRIPTION
Attempt to implement issue #21

Current concerns:
- [x] Changing reuseIdentifiers to objects makes it hard to use them as strings, maybe we should make a seperate category of this "higher level" R.swift feature?
(I want it to be simple to start using R.swift and not force users to use our higher level functions as this could mean being not able to use R values in certain edge cases.)

- [x] CollectionView support missing
- [x] TableView header/footer support missing
- [x] Registering nibs should also be less messy