### PR TITLE
Handle asset catalog sub-folders

### DIFF
--- a/R.swift/types.swift
+++ b/R.swift/types.swift
@@ -156,8 +156,23 @@ struct AssetFolder {
   init(url: NSURL, fileManager: NSFileManager) {
     name = url.filename!
 
-    let contents = fileManager.contentsOfDirectoryAtURL(url, includingPropertiesForKeys: nil, options: NSDirectoryEnumerationOptions.SkipsHiddenFiles, error: nil) as! [NSURL]
-    imageAssets = contents.map { $0.filename! }
+    // Authorized asset extensions
+    let assetExtensions = ["appiconset", "launchimage", "imageset"]
+
+    // Browse asset directory recursively and list the authorized assets list.
+    var assets = [NSURL]()
+    let enumerator = fileManager.enumeratorAtURL(url, includingPropertiesForKeys: nil,
+        options: .SkipsHiddenFiles, errorHandler: nil)
+    if let enumerator = enumerator {
+        for file in enumerator {
+            let fileURL = file as! NSURL
+            if let pathExtension = fileURL.pathExtension where find(assetExtensions, pathExtension) != nil {
+                assets.append(file as! NSURL)
+            }
+        }
+    }
+    
+    imageAssets = assets.map { $0.filename! }
   }
 }
 


### PR DESCRIPTION
Hi,

I like to put my images in sub-folders in an asset catalog, this ease the find and reading of assets when you have a lot of them.

R.swift was not listing these images, it was only listing the images at the root of an asset catalog. Here is a change to add these images in the image struct.

This change places all images in the same struct. As a future improvement, we could put them in a struct that represents the folder in which the image was.