### PR TITLE
Support nibs with spaces in name

### DIFF
--- a/R.swift/func.swift
+++ b/R.swift/func.swift
@@ -149,8 +149,8 @@ func internalNibStructFromNibs(nibs: [Nib]) -> Struct {
 }
 
 func nibVarForNib(nib: Nib) -> Var {
-  let structType = Type(name: "_R.nib._\(nib.name)")
-  return Var(isStatic: true, name: nib.name, type: structType, getter: "return \(structType)()")
+  let structType = Type(name: "_R.nib._\(nib.symbolName)")
+  return Var(isStatic: true, name: nib.symbolName, type: structType, getter: "return \(structType)()")
 }
 
 func nibStructForNib(nib: Nib) -> Struct {

--- a/R.swift/types.swift
+++ b/R.swift/types.swift
@@ -316,11 +316,13 @@ struct Storyboard: ReusableContainer {
 
 struct Nib: ReusableContainer {
   let name: String
+  let symbolName: String
   let rootViews: [Type]
   let reusables: [Reusable]
 
   init(url: NSURL) {
     name = url.filename!
+    symbolName = name.stringByReplacingOccurrencesOfString(" ", withString: "", options: nil, range: nil)
 
     let parserDelegate = NibParserDelegate();
 


### PR DESCRIPTION
Hello there!
I have a nib in my project named "Launch Screen.xib", which I am pretty sure has been generated by Xcode. 

R.swift generated uncompilable code, because using file name as a symbol. Here's a quick fix to differentiate nib name and variable name. Hope it is fine for you :)