### PR TITLE
Add support for custom fonts

### DIFF
--- a/R.swift/func.swift
+++ b/R.swift/func.swift
@@ -262,3 +262,30 @@ func swiftCallStoryboardValidators(storyboard: Storyboard) -> String {
     "storyboard.\(sanitizedSwiftName(storyboard.name)).validateImages()\n" +
     "storyboard.\(sanitizedSwiftName(storyboard.name)).validateViewControllers()"
 }
+
+func fontStructFromFonts(fonts: Font) -> Struct {
+    let fontNames = Type(name:"font")
+    var functions = [Function]()
+    var vars = [Var]()
+
+    for postsScriptName in fonts.customPostsciptNames {
+        vars.append(Var(
+            isStatic:true,
+            name: "\(postsScriptName.lowercaseFirstCharacter) Name",
+            type: Type._String,
+            getter: "return \"\(postsScriptName)\""
+            )
+        )
+        
+        functions.append(Function(
+            isStatic:true,
+            name: postsScriptName,
+            generics: nil,
+            parameters: [Function.Parameter(name: "size", localName: "size", type: Type._CGFloat, defaultValue: "0")],
+            returnType: Type._UIFont.asOptional(),
+            body:"return UIFont(name: \"\(postsScriptName)\", size: size)"
+            ))
+    }
+
+    return Struct(type: fontNames, implements: [], lets: [], vars: vars, functions: functions, structs: [])
+}

--- a/R.swift/func.swift
+++ b/R.swift/func.swift
@@ -281,7 +281,7 @@ func fontStructFromFonts(fonts: Font) -> Struct {
             isStatic:true,
             name: postsScriptName,
             generics: nil,
-            parameters: [Function.Parameter(name: "size", localName: "size", type: Type._CGFloat, defaultValue: "0")],
+            parameters: [Function.Parameter(name: "size", localName: nil, type: Type._CGFloat, defaultValue: "0")],
             returnType: Type._UIFont.asOptional(),
             body:"return UIFont(name: \"\(postsScriptName)\", size: size)"
             ))

--- a/R.swift/main.swift
+++ b/R.swift/main.swift
@@ -37,6 +37,8 @@ inputDirectories(NSProcessInfo.processInfo())
     let reusables = (nibs.map { $0 as ReusableContainer } + storyboards.map { $0 as ReusableContainer })
       .flatMap { $0.reusables }
 
+    let fonts = Font(url: directory, fileManager: defaultFileManager)
+
     // Generate resource file contents
     let resourceStruct = Struct(
       type: Type(name: "R"),
@@ -47,6 +49,7 @@ inputDirectories(NSProcessInfo.processInfo())
       ],
       structs: [
         imageStructFromAssetFolders(assetFolders),
+        fontStructFromFonts(fonts),
         segueStructFromStoryboards(storyboards),
         storyboardStructFromStoryboards(storyboards),
         nibStructFromNibs(nibs),

--- a/R.swift/types.swift
+++ b/R.swift/types.swift
@@ -43,6 +43,8 @@ struct Type: CustomStringConvertible, Equatable {
   static let _UICollectionViewCell = Type(name: "UICollectionViewCell")
   static let _UICollectionReusableView = Type(name: "UICollectionReusableView")
   static let _UIViewController = Type(name: "UIViewController")
+  static let _UIFont = Type(name: "UIFont")
+  static let _CGFloat = Type(name: "CGFloat")
 
   let module: String?
   let name: String
@@ -502,4 +504,31 @@ class NibParserDelegate: NSObject, NSXMLParserDelegate {
 
     return nil
   }
+}
+
+
+struct Font {
+    let customPostsciptNames: [String]
+
+    init(url: NSURL, fileManager: NSFileManager) {
+        customPostsciptNames = {
+            // Browse asset directory recursively and list only the fonts files
+            var customPostsciptNames = [String]()
+            let enumerator = fileManager.enumeratorAtURL(url, includingPropertiesForKeys: nil, options: .SkipsHiddenFiles, errorHandler: nil)
+            if let enumerator = enumerator {
+                for file in enumerator {
+                    if let fileURL = file as? NSURL, pathExtension = fileURL.pathExtension where FontExtensions.indexOf(pathExtension) != nil {
+                        let fontDataProvider = CGDataProviderCreateWithURL(fileURL);
+                        let customFont = CGFontCreateWithDataProvider(fontDataProvider);
+                        if let postsciptName = CGFontCopyPostScriptName(customFont) {
+                            customPostsciptNames.append(postsciptName as String)
+                        } else {
+                            print("Error: No postcriptName associated to \(fileURL)") //Should never happen anyway
+                        }
+                    }
+                }
+            }
+            return customPostsciptNames
+        }()
+    }
 }

--- a/R.swift/values.swift
+++ b/R.swift/values.swift
@@ -245,6 +245,8 @@ let Ordinals = [
 
 let AssetExtensions = ["launchimage", "imageset"] // "appiconset" is not loadable by default, so it's not included here
 
+let FontExtensions = ["ttf", "otf"] 
+
 let ElementNameToTypeMapping = [
   "viewController": Type._UIViewController,
   "tableViewCell": Type(name: "UITableViewCell"),

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ R.swift currently supports:
 - [X] Storyboards
 - [X] Nibs
 - [X] Reusable cells
+- [X] Custom fonts
 - [ ] Files in your bundle
 
 Below you find the different formats:
@@ -46,6 +47,7 @@ Nib              | `R.nib.[nibName].instance`                                 | 
 Nib all views    | `R.nib.[nibName].instantiateWithOwner(nil, options: nil)`  | `UINib(nibName: "TextCell", bundle: nil).instantiateWithOwner(nil, options: nil)`  | `R.nib.textCell.instantiateWithOwner(nil, options: nil)`
 Nib first view   | `R.nib.[nibName].firstView(nil, options: nil)`             | `UINib(nibName: "TextCell", bundle: nil).instantiateWithOwner(nil, options: nil).first as? TextCell` | `R.nib.textCell.firstView(nil, nil)`
 Reuse identifier | `R.reuseIdentifier.[name]`                                 | `"TextCell"`                              | `R.reuseIdentifier.textCell`
+NSFont | `R.font.[name](42)`                                 | `NSFont(name: "name" size: 42)`                              | `R.reuseIdentifier.textCell`
 
 Validate usage of images in Storyboards with `R.validate()` or to validate a specific storyboard use `R.storyboard.[storyboardName].validateImages()`. Please note that this uses `assert` and will only work in unoptimized debug builds.
 


### PR DESCRIPTION
From https://github.com/mac-cain13/R.swift/issues/38
Finally, no need to use options or weird path.
Does not yet support system fonts (needs quite some extra work to add available annotations to R.swift).
