### PR TITLE
Work on typed segues

### DIFF
--- a/R.swift/func.swift
+++ b/R.swift/func.swift
@@ -276,7 +276,7 @@ func varFromReusable(reusable: Reusable) -> Var {
   return Var(
     isStatic: true,
     name: reusable.identifier,
-    type: ReuseIdentifier.type.withGenericType(reusable.type),
+    type: ReuseIdentifier.type.withGenericArgs([reusable.type.name]),
     getter: "return \(ReuseIdentifier.type.name)(identifier: \"\(reusable.identifier)\")"
   )
 }

--- a/R.swift/func.swift
+++ b/R.swift/func.swift
@@ -101,10 +101,31 @@ func imageStructFromAssetFolders(assetFolders: [AssetFolder]) -> Struct {
 // Segue
 
 func segueStructFromStoryboards(storyboards: [Storyboard]) -> Struct {
+  let groupedViewControllers = storyboards
+    .flatMap { $0.viewControllers }
+    .groupBy { $0.id }
+
+  var structs: [Struct] = []
+  for group in groupedViewControllers {
+    if let vc = group.first {
+      var segues: [Var] = []
+      for segue in vc.segues {
+        let type = Type(name: "StoryboardSegue", genericArgs: [vc.type.name, segue.destination], optional: false)
+        let _var = Var(isStatic: true, name: segue.identifier, type: type, getter: "return StoryboardSegue(identifier: \"\(segue.identifier)\")")
+        segues.append(_var)
+      }
+
+      if segues.count > 0 {
+        let _struct = Struct(type: Type(name: vc.type.name), lets: [], vars: segues, functions: [], structs: [])
+        structs.append(_struct)
+      }
+    }
+  }
+
   let vars = Array(Set(storyboards.flatMap { $0.segues }))
     .map { Var(isStatic: true, name: $0, type: Type._String, getter: "return \"\($0)\"") }
 
-  return Struct(type: Type(name: "segue"), lets: [], vars: vars, functions: [], structs: [])
+  return Struct(type: Type(name: "segue"), lets: [], vars: vars, functions: [], structs: structs)
 }
 
 // Storyboard

--- a/R.swift/main.swift
+++ b/R.swift/main.swift
@@ -80,6 +80,7 @@ inputDirectories(NSProcessInfo.processInfo())
       resourceStruct.description, "",
       internalResourceStruct.description, "",
       ReuseIdentifier.description, "",
+      StoryboardSegue.description, "",
       NibResourceProtocol.description, "",
       ReusableProtocol.description, "",
       ReuseIdentifierUITableViewExtension.description, "",

--- a/R.swift/types.swift
+++ b/R.swift/types.swift
@@ -382,6 +382,12 @@ struct Storyboard: ReusableContainer {
     let id: String
     let storyboardIdentifier: String?
     let type: Type
+    let segues: [Segue]
+  }
+
+  struct Segue {
+    let identifier: String
+    let destination: String
   }
 }
 
@@ -452,7 +458,7 @@ class StoryboardParserDelegate: NSObject, NSXMLParserDelegate {
 
       let type = customType ?? ElementNameToTypeMapping[elementName] ?? Type._UIViewController
 
-      return Storyboard.ViewController(id: id, storyboardIdentifier: storyboardIdentifier, type: type)
+      return Storyboard.ViewController(id: id, storyboardIdentifier: storyboardIdentifier, type: type, segues: [])
     }
 
     return nil

--- a/R.swift/types.swift
+++ b/R.swift/types.swift
@@ -17,15 +17,9 @@ protocol ReusableContainer {
   var reusables: [Reusable] { get }
 }
 
-class Box<T> {
-  let value: T
-
-  init(value: T) {
-    self.value = value
-  }
-}
-
 /// MARK: Swift types
+
+typealias TypeVar = String
 
 struct Type: CustomStringConvertible, Equatable, Hashable {
   static let _Void = Type(name: "Void")
@@ -48,14 +42,15 @@ struct Type: CustomStringConvertible, Equatable, Hashable {
 
   let module: String?
   let name: String
-  let genericTypeBox: Box<Type?>
+  let genericArgs: [TypeVar]
   let optional: Bool
 
   var fullyQualifiedName: String {
     let optionalString = optional ? "?" : ""
 
-    if let genericType = genericTypeBox.value {
-      return "\(fullName)<\(genericType)>\(optionalString)"
+    if genericArgs.count > 0 {
+      let args = genericArgs.joinWithSeparator(", ")
+      return "\(fullName)<\(args)>\(optionalString)"
     }
 
     return "\(fullName)\(optionalString)"
@@ -78,30 +73,30 @@ struct Type: CustomStringConvertible, Equatable, Hashable {
     return "\(fullName)\(optionalString)".hashValue
   }
 
-  init(name: String, genericType: Type? = nil, optional: Bool = false) {
+  init(name: String, genericArgs: [TypeVar] = [], optional: Bool = false) {
     self.module = nil
     self.name = name
-    self.genericTypeBox = Box(value: genericType)
+    self.genericArgs = genericArgs
     self.optional = optional
   }
 
-  init(module: String?, name: String, genericType: Type? = nil, optional: Bool = false) {
+  init(module: String?, name: String, genericArgs: [TypeVar] = [], optional: Bool = false) {
     self.module = module
     self.name = name
-    self.genericTypeBox = Box(value: genericType)
+    self.genericArgs = genericArgs
     self.optional = optional
   }
 
   func asOptional() -> Type {
-    return Type(module: module, name: name, genericType: genericTypeBox.value, optional: true)
+    return Type(module: module, name: name, genericArgs: genericArgs, optional: true)
   }
 
   func asNonOptional() -> Type {
-    return Type(module: module, name: name, genericType: genericTypeBox.value, optional: false)
+    return Type(module: module, name: name, genericArgs: genericArgs, optional: false)
   }
 
-  func withGenericType(genericType: Type) -> Type {
-    return Type(module: module, name: name, genericType: genericType, optional: optional)
+  func withGenericArgs(genericArgs: [TypeVar]) -> Type {
+    return Type(module: module, name: name, genericArgs: genericArgs, optional: optional)
   }
 }
 

--- a/R.swift/values.swift
+++ b/R.swift/values.swift
@@ -41,6 +41,47 @@ let ReuseIdentifier = Struct(
   functions: [],
   structs: [])
 
+
+let StoryboardSegue = Struct(
+  type: Type(name: "StoryboardSegue", genericArgs: ["Source", "Destination"]),
+  implements: [Type(name: "CustomStringConvertible")],
+  lets: [
+    Let(
+      name: "identifier",
+      type: Type(name: "String")
+    )
+  ],
+  vars: [
+    Var(
+      isStatic: false,
+      name: "description",
+      type: Type(name: "String"),
+      getter: "return identifier"
+    )
+  ],
+  functions: [
+    Function(
+      isStatic: false,
+      name: "sourceViewController",
+      generics: nil,
+      parameters: [
+        Function.Parameter(name: "segue", type: Type(name: "UIStoryboardSegue"))
+      ],
+      returnType: Type(name: "Source", optional: true),
+      body: "return segue.sourceViewController as? Source"
+    ),
+    Function(
+      isStatic: false,
+      name: "destinationViewController",
+      generics: nil,
+      parameters: [
+        Function.Parameter(name: "segue", type: Type(name: "UIStoryboardSegue"))
+      ],
+      returnType: Type(name: "Destination", optional: true),
+      body: "return segue.destinationViewController as? Destination"
+    )],
+  structs: [])
+
 let NibResourceProtocol = Protocol(
   type: Type(name: "NibResource"),
   typealiasses: [],

--- a/R.swift/values.swift
+++ b/R.swift/values.swift
@@ -22,7 +22,7 @@ let Imports = [
 
 
 let ReuseIdentifier = Struct(
-  type: Type(name: "ReuseIdentifier", genericType: Type(name: "T")),
+  type: Type(name: "ReuseIdentifier", genericArgs: ["T"]),
   implements: [Type(name: "CustomStringConvertible")],
   lets: [
     Let(
@@ -84,7 +84,7 @@ let ReuseIdentifierUITableViewExtension = Extension(
         Function.Parameter(name: "identifier", type: ReuseIdentifier.type),
         Function.Parameter(name: "forIndexPath", localName: "indexPath", type: Type._NSIndexPath.asOptional())
       ],
-      returnType: Type(name: "T", genericType: nil, optional: true),
+      returnType: Type(name: "T", optional: true),
       body: "if let indexPath = indexPath {\n  return dequeueReusableCellWithIdentifier(identifier.identifier, forIndexPath: indexPath) as? T\n}\nreturn dequeueReusableCellWithIdentifier(identifier.identifier) as? T"
     ),
 
@@ -95,7 +95,7 @@ let ReuseIdentifierUITableViewExtension = Extension(
       parameters: [
         Function.Parameter(name: "identifier", type: ReuseIdentifier.type),
       ],
-      returnType: Type(name: "T", genericType: nil, optional: true),
+      returnType: Type(name: "T", optional: true),
       body: "return dequeueReusableCellWithIdentifier(identifier.identifier) as? T"
     ),
 
@@ -106,7 +106,7 @@ let ReuseIdentifierUITableViewExtension = Extension(
       parameters: [
         Function.Parameter(name: "identifier", type: ReuseIdentifier.type),
       ],
-      returnType: Type(name: "T", genericType: nil, optional: true),
+      returnType: Type(name: "T", optional: true),
       body: "return dequeueReusableHeaderFooterViewWithIdentifier(identifier.identifier) as? T"
     ),
 
@@ -156,7 +156,7 @@ let ReuseIdentifierUICollectionViewExtension = Extension(
         Function.Parameter(name: "identifier", type: ReuseIdentifier.type),
         Function.Parameter(name: "forIndexPath", localName: "indexPath", type: Type._NSIndexPath)
       ],
-      returnType: Type(name: "T", genericType: nil, optional: true),
+      returnType: Type(name: "T", optional: true),
       body: "return dequeueReusableCellWithReuseIdentifier(identifier.identifier, forIndexPath: indexPath) as? T"
     ),
 
@@ -169,7 +169,7 @@ let ReuseIdentifierUICollectionViewExtension = Extension(
         Function.Parameter(name: "withReuseIdentifier", localName: "identifier", type: ReuseIdentifier.type),
         Function.Parameter(name: "forIndexPath", localName: "indexPath", type: Type._NSIndexPath)
       ],
-      returnType: Type(name: "T", genericType: nil, optional: true),
+      returnType: Type(name: "T", optional: true),
       body: "return dequeueReusableSupplementaryViewOfKind(elementKind, withReuseIdentifier: identifier.identifier, forIndexPath: indexPath) as? T"
     ),
 


### PR DESCRIPTION
_This pull request is a work in progress._

I've started the work for typed segues as discussed in https://github.com/mac-cain13/R.swift/issues/71
This isn't complete yet (XML Storyboard parsing isn't done).

Question: Do we want to remove the existing `R.segue.something` segues in favour of the `R.segue.MyViewController.something`?
It seems weird to duplicate them, although the newer typed ones are more complicated and this would be a backward compatibility breaking change.

Todo:

 - [ ] Adapt Storyboard XML parser to generate `Storyboard.Segue` values
 - [ ] Create test cases