### PR TITLE
Feature/use project file

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "Xcode.swift"]
+	path = Xcode.swift
+	url = https://github.com/mac-cain13/Xcode.swift.git

--- a/R.swift.xcodeproj/project.pbxproj
+++ b/R.swift.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		D5032B691A7C1542007D1107 /* types.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5032B681A7C1542007D1107 /* types.swift */; };
+		D579466B1B9347C20044D2FC /* XCProjectFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = D579466A1B9347C20044D2FC /* XCProjectFile.swift */; settings = {ASSET_TAGS = (); }; };
+		D579466C1B9347C80044D2FC /* XCProjectFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = D579466A1B9347C20044D2FC /* XCProjectFile.swift */; settings = {ASSET_TAGS = (); }; };
 		D5B53A171A7D2A9B00F64418 /* values.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5B53A161A7D2A9B00F64418 /* values.swift */; };
 		D5C422851B7121BD004EA9B9 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5EA0DF71A3DF45600FFEBC4 /* main.swift */; };
 		D5C422861B7121BD004EA9B9 /* func.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5F105FE1A3E2BC30077263A /* func.swift */; };
@@ -15,6 +17,10 @@
 		D5C422881B7121BD004EA9B9 /* util.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5EA0DFE1A3DF4E300FFEBC4 /* util.swift */; };
 		D5C422891B7121BD004EA9B9 /* values.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5B53A161A7D2A9B00F64418 /* values.swift */; };
 		D5C4228B1B714E0D004EA9B9 /* utilTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5C4228A1B714E0D004EA9B9 /* utilTests.swift */; };
+		D5CD9B3C1B98258700C85F8C /* input.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5CD9B3B1B98258700C85F8C /* input.swift */; settings = {ASSET_TAGS = (); }; };
+		D5DA249B1B9B445F00AAA43E /* input.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5CD9B3B1B98258700C85F8C /* input.swift */; settings = {ASSET_TAGS = (); }; };
+		D5DA249D1B9CB1BF00AAA43E /* processing.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5DA249C1B9CB1BF00AAA43E /* processing.swift */; settings = {ASSET_TAGS = (); }; };
+		D5DA249E1B9CB21B00AAA43E /* processing.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5DA249C1B9CB1BF00AAA43E /* processing.swift */; settings = {ASSET_TAGS = (); }; };
 		D5EA0DF81A3DF45600FFEBC4 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5EA0DF71A3DF45600FFEBC4 /* main.swift */; };
 		D5EA0DFF1A3DF4E300FFEBC4 /* util.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5EA0DFE1A3DF4E300FFEBC4 /* util.swift */; };
 		D5F105FF1A3E2BC30077263A /* func.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5F105FE1A3E2BC30077263A /* func.swift */; };
@@ -22,10 +28,13 @@
 
 /* Begin PBXFileReference section */
 		D5032B681A7C1542007D1107 /* types.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = types.swift; sourceTree = "<group>"; };
+		D579466A1B9347C20044D2FC /* XCProjectFile.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XCProjectFile.swift; sourceTree = "<group>"; };
 		D5B53A161A7D2A9B00F64418 /* values.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = values.swift; sourceTree = "<group>"; };
 		D5C4227D1B711FDF004EA9B9 /* rswiftTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = rswiftTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D5C422811B711FDF004EA9B9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D5C4228A1B714E0D004EA9B9 /* utilTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = utilTests.swift; sourceTree = "<group>"; };
+		D5CD9B3B1B98258700C85F8C /* input.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = input.swift; sourceTree = "<group>"; };
+		D5DA249C1B9CB1BF00AAA43E /* processing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = processing.swift; sourceTree = "<group>"; };
 		D5EA0DF41A3DF45600FFEBC4 /* rswift */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = rswift; sourceTree = BUILT_PRODUCTS_DIR; };
 		D5EA0DF71A3DF45600FFEBC4 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		D5EA0DFE1A3DF4E300FFEBC4 /* util.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = util.swift; sourceTree = "<group>"; };
@@ -43,6 +52,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		D57946691B9347A70044D2FC /* Xcode.swift */ = {
+			isa = PBXGroup;
+			children = (
+				D579466A1B9347C20044D2FC /* XCProjectFile.swift */,
+			);
+			name = Xcode.swift;
+			path = Xcode.swift/Xcode/Xcode;
+			sourceTree = "<group>";
+		};
 		D5C4227E1B711FDF004EA9B9 /* R.swiftTests */ = {
 			isa = PBXGroup;
 			children = (
@@ -56,6 +74,7 @@
 			isa = PBXGroup;
 			children = (
 				D5EA0DF61A3DF45600FFEBC4 /* R.swift */,
+				D57946691B9347A70044D2FC /* Xcode.swift */,
 				D5C4227E1B711FDF004EA9B9 /* R.swiftTests */,
 				D5EA0DF51A3DF45600FFEBC4 /* Products */,
 			);
@@ -74,6 +93,8 @@
 			isa = PBXGroup;
 			children = (
 				D5EA0DF71A3DF45600FFEBC4 /* main.swift */,
+				D5CD9B3B1B98258700C85F8C /* input.swift */,
+				D5DA249C1B9CB1BF00AAA43E /* processing.swift */,
 				D5F105FE1A3E2BC30077263A /* func.swift */,
 				D5032B681A7C1542007D1107 /* types.swift */,
 				D5EA0DFE1A3DF4E300FFEBC4 /* util.swift */,
@@ -189,10 +210,13 @@
 			files = (
 				D5C422851B7121BD004EA9B9 /* main.swift in Sources */,
 				D5C4228B1B714E0D004EA9B9 /* utilTests.swift in Sources */,
+				D5DA249E1B9CB21B00AAA43E /* processing.swift in Sources */,
 				D5C422861B7121BD004EA9B9 /* func.swift in Sources */,
 				D5C422881B7121BD004EA9B9 /* util.swift in Sources */,
 				D5C422871B7121BD004EA9B9 /* types.swift in Sources */,
 				D5C422891B7121BD004EA9B9 /* values.swift in Sources */,
+				D5DA249B1B9B445F00AAA43E /* input.swift in Sources */,
+				D579466C1B9347C80044D2FC /* XCProjectFile.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -200,10 +224,13 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D5DA249D1B9CB1BF00AAA43E /* processing.swift in Sources */,
 				D5EA0DF81A3DF45600FFEBC4 /* main.swift in Sources */,
 				D5EA0DFF1A3DF4E300FFEBC4 /* util.swift in Sources */,
 				D5F105FF1A3E2BC30077263A /* func.swift in Sources */,
 				D5B53A171A7D2A9B00F64418 /* values.swift in Sources */,
+				D579466B1B9347C20044D2FC /* XCProjectFile.swift in Sources */,
+				D5CD9B3C1B98258700C85F8C /* input.swift in Sources */,
 				D5032B691A7C1542007D1107 /* types.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/R.swift.xcodeproj/xcshareddata/xcschemes/rswift.xcscheme
+++ b/R.swift.xcodeproj/xcshareddata/xcschemes/rswift.xcscheme
@@ -87,7 +87,15 @@
       </BuildableProductRunnable>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "$SRCROOT/ResourceApp"
+            argument = "$SRCROOT/ResourceApp/ResourceApp.xcodeproj"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "ResourceApp"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "$SRCROOT/ResourceApp/"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/R.swift.xcodeproj/xcshareddata/xcschemes/rswift.xcscheme
+++ b/R.swift.xcodeproj/xcshareddata/xcschemes/rswift.xcscheme
@@ -87,18 +87,42 @@
       </BuildableProductRunnable>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "$SRCROOT/ResourceApp/ResourceApp.xcodeproj"
-            isEnabled = "YES">
-         </CommandLineArgument>
-         <CommandLineArgument
-            argument = "ResourceApp"
-            isEnabled = "YES">
-         </CommandLineArgument>
-         <CommandLineArgument
-            argument = "$SRCROOT/ResourceApp/"
+            argument = "$SRCROOT/ResourceApp"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "PROJECT_FILE_PATH"
+            value = "$SRCROOT/ResourceApp/ResourceApp.xcodeproj"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "TARGET_NAME"
+            value = "ResourceApp"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "BUILT_PRODUCTS_DIR"
+            value = "/tmp"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "SDKROOT"
+            value = "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator9.0.sdk"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "DEVELOPER_DIR"
+            value = "/Applications/Xcode.app/Contents/Developer"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "SOURCE_ROOT"
+            value = "$SRCROOT/ResourceApp/"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>

--- a/R.swift.xcworkspace/xcshareddata/R.swift.xcscmblueprint
+++ b/R.swift.xcworkspace/xcshareddata/R.swift.xcscmblueprint
@@ -1,0 +1,30 @@
+{
+  "DVTSourceControlWorkspaceBlueprintPrimaryRemoteRepositoryKey" : "768F1F9CC867EF28C17472B184F0AF0781227AAE",
+  "DVTSourceControlWorkspaceBlueprintWorkingCopyRepositoryLocationsKey" : {
+
+  },
+  "DVTSourceControlWorkspaceBlueprintWorkingCopyStatesKey" : {
+    "69AF840D792779EDC1501DFB94242F79649CD44F" : 0,
+    "768F1F9CC867EF28C17472B184F0AF0781227AAE" : 0
+  },
+  "DVTSourceControlWorkspaceBlueprintIdentifierKey" : "2745F2D3-03ED-4C52-9A79-2F24D94BB864",
+  "DVTSourceControlWorkspaceBlueprintWorkingCopyPathsKey" : {
+    "69AF840D792779EDC1501DFB94242F79649CD44F" : "R.swift\/Xcode.swift\/",
+    "768F1F9CC867EF28C17472B184F0AF0781227AAE" : "R.swift\/"
+  },
+  "DVTSourceControlWorkspaceBlueprintNameKey" : "R.swift",
+  "DVTSourceControlWorkspaceBlueprintVersion" : 204,
+  "DVTSourceControlWorkspaceBlueprintRelativePathToProjectKey" : "R.swift.xcworkspace",
+  "DVTSourceControlWorkspaceBlueprintRemoteRepositoriesKey" : [
+    {
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryURLKey" : "https:\/\/github.com\/mac-cain13\/Xcode.swift.git",
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositorySystemKey" : "com.apple.dt.Xcode.sourcecontrol.Git",
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryIdentifierKey" : "69AF840D792779EDC1501DFB94242F79649CD44F"
+    },
+    {
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryURLKey" : "github.com:mac-cain13\/R.swift.git",
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositorySystemKey" : "com.apple.dt.Xcode.sourcecontrol.Git",
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryIdentifierKey" : "768F1F9CC867EF28C17472B184F0AF0781227AAE"
+    }
+  ]
+}

--- a/R.swift/func.swift
+++ b/R.swift/func.swift
@@ -87,7 +87,7 @@ func imageStructFromAssetFolders(assetFolders: [AssetFolder]) -> Struct {
     .groupUniquesAndDuplicates { $0.callName }
 
   for duplicate in vars.duplicates {
-    let names = duplicate.map { $0.name }.joinWithSeparator(", ")
+    let names = duplicate.map { $0.name }.sort().joinWithSeparator(", ")
     warn("Skipping \(duplicate.count) images because symbol '\(duplicate.first!.callName)' would be generated for all of these images: \(names)")
   }
 
@@ -109,7 +109,7 @@ func storyboardStructAndFunctionFromStoryboards(storyboards: [Storyboard]) -> (S
   let groupedStoryboards = storyboards.groupUniquesAndDuplicates { sanitizedSwiftName($0.name) }
 
   for duplicate in groupedStoryboards.duplicates {
-    let names = duplicate.map { $0.name }.joinWithSeparator(", ")
+    let names = duplicate.map { $0.name }.sort().joinWithSeparator(", ")
     warn("Skipping \(duplicate.count) storyboards because symbol '\(sanitizedSwiftName(duplicate.first!.name))' would be generated for all of these storyboards: \(names)")
   }
 
@@ -168,7 +168,7 @@ func nibStructFromNibs(nibs: [Nib]) -> (intern: Struct, extern: Struct) {
   let groupedNibs = nibs.groupUniquesAndDuplicates { sanitizedSwiftName($0.name) }
 
   for duplicate in groupedNibs.duplicates {
-    let names = duplicate.map { $0.name }.joinWithSeparator(", ")
+    let names = duplicate.map { $0.name }.sort().joinWithSeparator(", ")
     warn("Skipping \(duplicate.count) xibs because symbol '\(sanitizedSwiftName(duplicate.first!.name))' would be generated for all of these xibs: \(names)")
   }
 
@@ -260,7 +260,7 @@ func reuseIdentifierStructFromReusables(reusables: [Reusable]) -> Struct {
   let groupedReusables = reusables.groupUniquesAndDuplicates { sanitizedSwiftName($0.identifier) }
 
   for duplicate in groupedReusables.duplicates {
-    let names = duplicate.map { $0.identifier }.joinWithSeparator(", ")
+    let names = duplicate.map { $0.identifier }.sort().joinWithSeparator(", ")
     warn("Skipping \(duplicate.count) reuseIdentifiers because symbol '\(sanitizedSwiftName(duplicate.first!.identifier))' would be generated for all of these reuseIdentifiers: \(names)")
   }
 

--- a/R.swift/func.swift
+++ b/R.swift/func.swift
@@ -25,10 +25,6 @@ func fail<T: ErrorType where T: CustomStringConvertible>(error: T) {
   fail("\(error)")
 }
 
-func inputDirectories(processInfo: NSProcessInfo) -> [NSURL] {
-  return processInfo.arguments.skip(1).map { NSURL(fileURLWithPath: $0) }
-}
-
 func filterDirectoryContentsRecursively(fileManager: NSFileManager, filter: (NSURL) -> Bool)(url: NSURL) -> [NSURL] {
   var assetFolders = [NSURL]()
 

--- a/R.swift/input.swift
+++ b/R.swift/input.swift
@@ -9,34 +9,91 @@
 
 import Foundation
 
-enum InputParsingError: ErrorType {
+enum InputParsingError: ErrorType, CustomStringConvertible {
   case MissingArguments(String)
+  case MissingEnvironmentVariables(String)
   case InvalidArgument(String)
+
+  var description: String {
+    switch self {
+    case let .MissingArguments(desc):
+      return desc
+    case let .MissingEnvironmentVariables(desc):
+      return desc
+    case let .InvalidArgument(desc):
+      return desc
+    }
+  }
 }
 
 struct CallInformation {
   let rswiftCall: String
+  let outputFolderPath: String
+
   let xcodeprojPath: String
   let targetName: String
-  let outputFolderPath: String
+
+  let buildProductsDir: String
+  let developerDir: String
+  let sourceRoot: String
+  let sdkRoot: String
 
   init(processInfo: NSProcessInfo) throws {
     let arguments = processInfo.arguments
     guard let rswiftCall = arguments[safe: 0],
-      xcodeprojPath = arguments[safe: 1],
-      targetName = arguments[safe: 2],
-      outputFolderPath = arguments[safe: 3] else {
-        throw InputParsingError.MissingArguments("Incorrect call to R.swift, must be of format 'rswift [projectFile] [targetName] [outputFolder]'")
+      outputFolderPath = arguments[safe: 1]
+    else {
+      throw InputParsingError.MissingArguments("Incorrect call to R.swift, must be of format 'rswift [outputFolder]'")
+    }
+
+    let environment = processInfo.environment
+    guard let xcodeprojPath = environment["PROJECT_FILE_PATH"],
+      targetName = environment["TARGET_NAME"],
+      buildProductsDir = environment["BUILT_PRODUCTS_DIR"],
+      developerDir = environment["DEVELOPER_DIR"],
+      sourceRoot = environment["SOURCE_ROOT"],
+      sdkRoot = environment["SDKROOT"]
+    else {
+      throw InputParsingError.MissingArguments("Incompatible environment, the following variables must be available: PROJECT_FILE_PATH, TARGET_NAME, BUILT_PRODUCTS_DIR, DEVELOPER_DIR, SOURCE_ROOT, SDKROOT")
     }
 
     self.rswiftCall = rswiftCall
+    self.outputFolderPath = outputFolderPath
+
     self.xcodeprojPath = xcodeprojPath
     self.targetName = targetName
-    self.outputFolderPath = outputFolderPath
+
+    self.buildProductsDir = buildProductsDir
+    self.developerDir = developerDir
+    self.sourceRoot = sourceRoot
+    self.sdkRoot = sdkRoot
+  }
+
+  func pathFromSourceTreeFolder(sourceTreeFolder: SourceTreeFolder) -> String {
+    switch sourceTreeFolder {
+    case .BuildProductsDir:
+      return buildProductsDir
+    case .DeveloperDir:
+      return developerDir
+    case .SDKRoot:
+      return sdkRoot
+    case .SourceRoot:
+      return sourceRoot
+    }
   }
 }
 
-func resourcePathsInXcodeproj(xcodeprojPath: String, forTarget targetName: String) throws -> [String] {
+func pathResolverWithSourceTreeToPathConverter(pathFromSourceTreeFolder: SourceTreeFolder -> String)(path: Path) -> NSURL {
+  switch path {
+  case let .Absolute(absolutePath):
+    return NSURL(fileURLWithPath: absolutePath)
+  case let .RelativeTo(sourceTreeFolder, relativePath):
+    let sourceTreePath = pathFromSourceTreeFolder(sourceTreeFolder)
+    return NSURL(fileURLWithPath: sourceTreePath).URLByAppendingPathComponent(relativePath)
+  }
+}
+
+func resourceURLsInXcodeproj(xcodeprojPath: String, forTarget targetName: String, pathResolver: Path -> NSURL) throws -> [NSURL] {
   // Parse project file
   guard let projectFile = try? XCProjectFile(xcodeprojPath: xcodeprojPath) else {
     throw InputParsingError.InvalidArgument("Project file at '\(xcodeprojPath)' could not be parsed, is this a valid Xcode project file ending in *.xcodeproj?")
@@ -63,5 +120,6 @@ func resourcePathsInXcodeproj(xcodeprojPath: String, forTarget targetName: Strin
     .flatMap { $0.fileRefs }
     .map { $0.fullPath }
   
-  return fileRefPaths + variantGroupPaths
+  return (fileRefPaths + variantGroupPaths)
+    .map(pathResolver)
 }

--- a/R.swift/input.swift
+++ b/R.swift/input.swift
@@ -1,0 +1,67 @@
+//
+//  main.swift
+//  R.swift
+//
+//  Created by Mathijs Kadijk on 03-09-15.
+//  From: https://github.com/mac-cain13/R.swift
+//  License: MIT License
+//
+
+import Foundation
+
+enum InputParsingError: ErrorType {
+  case MissingArguments(String)
+  case InvalidArgument(String)
+}
+
+struct CallInformation {
+  let rswiftCall: String
+  let xcodeprojPath: String
+  let targetName: String
+  let outputFolderPath: String
+
+  init(processInfo: NSProcessInfo) throws {
+    let arguments = processInfo.arguments
+    guard let rswiftCall = arguments[safe: 0],
+      xcodeprojPath = arguments[safe: 1],
+      targetName = arguments[safe: 2],
+      outputFolderPath = arguments[safe: 3] else {
+        throw InputParsingError.MissingArguments("Incorrect call to R.swift, must be of format 'rswift [projectFile] [targetName] [outputFolder]'")
+    }
+
+    self.rswiftCall = rswiftCall
+    self.xcodeprojPath = xcodeprojPath
+    self.targetName = targetName
+    self.outputFolderPath = outputFolderPath
+  }
+}
+
+func resourcePathsInXcodeproj(xcodeprojPath: String, forTarget targetName: String) throws -> [String] {
+  // Parse project file
+  guard let projectFile = try? XCProjectFile(xcodeprojPath: xcodeprojPath) else {
+    throw InputParsingError.InvalidArgument("Project file at '\(xcodeprojPath)' could not be parsed, is this a valid Xcode project file ending in *.xcodeproj?")
+  }
+
+  // Look for target in project file
+  let allTargets = projectFile.project.targets
+  guard let target = allTargets.filter({ $0.productName == targetName }).first else {
+    let availableTargets = allTargets.map { $0.productName }.joinWithSeparator(", ")
+    throw InputParsingError.InvalidArgument("Target '\(targetName)' not found in project file, available targets are: \(availableTargets)")
+  }
+
+  let resourcesFileRefs = target.buildPhases
+    .flatMap { $0 as? PBXResourcesBuildPhase }
+    .flatMap { $0.files }
+    .map { $0.fileRef }
+
+  let fileRefPaths = resourcesFileRefs
+    .flatMap { $0 as? PBXFileReference }
+    .map { $0.fullPath }
+
+  let variantGroupPaths = resourcesFileRefs
+    .flatMap { $0 as? PBXVariantGroup }
+    .flatMap { $0.fileRefs }
+    .map { $0.fullPath }
+  
+  return fileRefPaths + variantGroupPaths
+}

--- a/R.swift/main.swift
+++ b/R.swift/main.swift
@@ -12,8 +12,8 @@ import Foundation
 do {
   let callInformation = try CallInformation(processInfo: NSProcessInfo.processInfo())
 
-  let resourceURLs = try resourcePathsInXcodeproj(callInformation.xcodeprojPath, forTarget: callInformation.targetName)
-    .flatMap { NSURL(fileURLWithPath: "\(callInformation.xcodeprojPath)/..\($0)").URLByStandardizingPath }
+  let resourceURLs = try resourceURLsInXcodeproj(callInformation.xcodeprojPath, forTarget: callInformation.targetName, pathResolver: pathResolverWithSourceTreeToPathConverter(callInformation.pathFromSourceTreeFolder))
+  print("\(resourceURLs)")
 
   let resources = Resources(resourceURLs: resourceURLs, fileManager: NSFileManager.defaultManager())
 
@@ -38,8 +38,6 @@ do {
     writeResourceFile(fileContents, toFolderURL: outputFolderURL)
   }
 
-} catch let InputParsingError.MissingArguments(humanReadableError) {
-  fail(humanReadableError)
-} catch let InputParsingError.InvalidArgument(humanReadableError) {
-  fail(humanReadableError)
+} catch let error as InputParsingError {
+  fail(error)
 }

--- a/R.swift/main.swift
+++ b/R.swift/main.swift
@@ -20,17 +20,17 @@ do {
   let (internalStruct, externalStruct) = generateResourceStructsWithResources(resources)
 
   let fileContents = [
-    Header, "",
-    Imports, "",
-    externalStruct.description, "",
-    internalStruct.description, "",
-    ReuseIdentifier.description, "",
-    NibResourceProtocol.description, "",
-    ReusableProtocol.description, "",
-    ReuseIdentifierUITableViewExtension.description, "",
-    ReuseIdentifierUICollectionViewExtension.description, "",
+    Header,
+    Imports,
+    externalStruct.description,
+    internalStruct.description,
+    ReuseIdentifier.description,
+    NibResourceProtocol.description,
+    ReusableProtocol.description,
+    ReuseIdentifierUITableViewExtension.description,
+    ReuseIdentifierUICollectionViewExtension.description,
     NibUIViewControllerExtension.description,
-    ].joinWithSeparator("\n")
+    ].joinWithSeparator("\n\n")
 
   // Write file if we have changes
   let outputFolderURL = NSURL(fileURLWithPath: callInformation.outputFolderPath)

--- a/R.swift/processing.swift
+++ b/R.swift/processing.swift
@@ -1,0 +1,79 @@
+//
+//  processing.swift
+//  R.swift
+//
+//  Created by Mathijs Kadijk on 06-09-15.
+//  From: https://github.com/mac-cain13/R.swift
+//  License: MIT License
+//
+
+import Foundation
+
+private func tryResourceParsing<T>(parse: () throws -> T) -> T? {
+  do {
+    return try parse()
+  } catch let ResourceParsingError.ParsingFailed(humanReadableError) {
+    warn(humanReadableError)
+    return nil
+  } catch ResourceParsingError.UnsupportedExtension {
+    return nil
+  } catch {
+    return nil
+  }
+}
+
+struct Resources {
+  let assetFolders: [AssetFolder]
+  let fonts: [Font]
+  let nibs: [Nib]
+  let storyboards: [Storyboard]
+
+  let reusables: [Reusable]
+
+  init(resourceURLs: [NSURL], fileManager: NSFileManager) {
+    assetFolders = resourceURLs.flatMap { url in tryResourceParsing { try AssetFolder(url: url, fileManager: fileManager) } }
+    fonts = resourceURLs.flatMap { url in tryResourceParsing { try Font(url: url) } }
+    nibs = resourceURLs.flatMap { url in tryResourceParsing { try Nib(url: url) } }
+    storyboards = resourceURLs.flatMap { url in tryResourceParsing { try Storyboard(url: url) } }
+
+    reusables = (nibs.map { $0 as ReusableContainer } + storyboards.map { $0 as ReusableContainer })
+      .flatMap { $0.reusables }
+  }
+}
+
+func generateResourceStructsWithResources(resources: Resources) -> (Struct, Struct) {
+  // Generate resource file contents
+  let storyboardStructAndFunction = storyboardStructAndFunctionFromStoryboards(resources.storyboards)
+
+  let nibStructs = nibStructFromNibs(resources.nibs)
+
+  let externalResourceStruct = Struct(
+    type: Type(name: "R"),
+    lets: [],
+    vars: [],
+    functions: [
+      storyboardStructAndFunction.1,
+    ],
+    structs: [
+      imageStructFromAssetFolders(resources.assetFolders),
+      fontStructFromFonts(resources.fonts),
+      segueStructFromStoryboards(resources.storyboards),
+      storyboardStructAndFunction.0,
+      nibStructs.extern,
+      reuseIdentifierStructFromReusables(resources.reusables),
+    ]
+  )
+
+  let internalResourceStruct = Struct(
+    type: Type(name: "_R"),
+    implements: [],
+    lets: [],
+    vars: [],
+    functions: [],
+    structs: [
+      nibStructs.intern
+    ]
+  )
+
+  return (internalResourceStruct, externalResourceStruct)
+}

--- a/R.swift/util.swift
+++ b/R.swift/util.swift
@@ -13,13 +13,13 @@ import Foundation
 // MARK: Array operations
 
 extension Array {
-  func skip(items: Int) -> [Element] {
-    return Array(self[items..<count])
+  subscript (safe index: Int) -> Element? {
+    return indices ~= index ? self[index] : nil
   }
 }
 
 extension SequenceType {
-  func groupBy<U: Hashable>(keySelector: Generator.Element -> U) -> [[Generator.Element]] {
+  func groupBy<U: Hashable>(keySelector: Generator.Element -> U) -> [U: [Generator.Element]] {
     var groupedBy = Dictionary<U, [Generator.Element]>()
 
     for element in self {
@@ -31,11 +31,11 @@ extension SequenceType {
       }
     }
 
-    return Array(groupedBy.values)
+    return groupedBy
   }
 
   func groupUniquesAndDuplicates<U: Hashable>(keySelector: Generator.Element -> U) -> (uniques: [Generator.Element], duplicates: [[Generator.Element]]) {
-    let groupedBy = groupBy(keySelector)
+    let groupedBy = Array(groupBy(keySelector).values)
     let uniques = groupedBy.filter { $0.count == 1 }.reduce([], combine: +)
     let duplicates = groupedBy.filter { $0.count > 1 }
 

--- a/ResourceApp/ResourceApp.xcodeproj/project.pbxproj
+++ b/ResourceApp/ResourceApp.xcodeproj/project.pbxproj
@@ -323,7 +323,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"$SRCROOT/rswift\" \"$PROJECT_FILE_PATH\" \"$TARGET_NAME\" \"\" > ./rswift.log";
+			shellScript = "\"$SRCROOT/rswift\" \"$PROJECT_FILE_PATH\" \"$TARGET_NAME\" \"$INFOPLIST_FILE/..\" > \"$SRCROOT/rswift.log\"";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/ResourceApp/ResourceApp.xcodeproj/project.pbxproj
+++ b/ResourceApp/ResourceApp.xcodeproj/project.pbxproj
@@ -323,7 +323,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"$SRCROOT/rswift\" \"$SRCROOT.\" > \"$SRCROOT/rswift.log\"";
+			shellScript = "\"$SRCROOT/rswift\" \"$SRCROOT\" > \"$SRCROOT/rswift.log\"";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/ResourceApp/ResourceApp.xcodeproj/project.pbxproj
+++ b/ResourceApp/ResourceApp.xcodeproj/project.pbxproj
@@ -323,7 +323,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"$SRCROOT/rswift\" \"$SRCROOT\" > ./rswift.log";
+			shellScript = "\"$SRCROOT/rswift\" \"$PROJECT_FILE_PATH\" \"$TARGET_NAME\" \"\" > ./rswift.log";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/ResourceApp/ResourceApp.xcodeproj/project.pbxproj
+++ b/ResourceApp/ResourceApp.xcodeproj/project.pbxproj
@@ -323,7 +323,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"$SRCROOT/rswift\" \"$PROJECT_FILE_PATH\" \"$TARGET_NAME\" \"$INFOPLIST_FILE/..\" > \"$SRCROOT/rswift.log\"";
+			shellScript = "\"$SRCROOT/rswift\" \"$SRCROOT.\" > \"$SRCROOT/rswift.log\"";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/ResourceApp/ResourceApp/Base.lproj/Main.storyboard
+++ b/ResourceApp/ResourceApp/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="8187.4" systemVersion="14F27" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="49e-Tb-3d3">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="8191" systemVersion="14F27" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="49e-Tb-3d3">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8151.3"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8154"/>
     </dependencies>
     <customFonts key="customFonts">
         <mutableArray key="Helvetica.ttc">

--- a/ResourceApp/ResourceApp/Duplicate/ADuplicateCellView.xib
+++ b/ResourceApp/ResourceApp/Duplicate/ADuplicateCellView.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="8173.3" systemVersion="14E46" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="8187.4" systemVersion="14F27" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8142"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8151.3"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>

--- a/ResourceApp/ResourceApp/DuplicateCellView.xib
+++ b/ResourceApp/ResourceApp/DuplicateCellView.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="8173.3" systemVersion="14E46" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="8187.4" systemVersion="14F27" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8142"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8151.3"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>

--- a/ResourceApp/ResourceAppTests/ResourceAppTests.swift
+++ b/ResourceApp/ResourceAppTests/ResourceAppTests.swift
@@ -14,9 +14,9 @@ class ResourceAppTests: XCTestCase {
 
   let expectedWarnings = [
     "warning: [R.swift] Skipping 2 images because symbol 'second' would be generated for all of these images: Second, second",
-    "warning: [R.swift] Skipping 2 xibs because symbol 'duplicate' would be generated for all of these xibs: duplicate, Duplicate",
-    "warning: [R.swift] Skipping 2 storyboards because symbol 'duplicate' would be generated for all of these storyboards: duplicate, Duplicate",
-    "warning: [R.swift] Skipping 2 reuseIdentifiers because symbol 'duplicateCellView' would be generated for all of these reuseIdentifiers: duplicateCellView, DuplicateCellView",
+    "warning: [R.swift] Skipping 2 xibs because symbol 'duplicate' would be generated for all of these xibs: Duplicate, duplicate",
+    "warning: [R.swift] Skipping 2 storyboards because symbol 'duplicate' would be generated for all of these storyboards: Duplicate, duplicate",
+    "warning: [R.swift] Skipping 2 reuseIdentifiers because symbol 'duplicateCellView' would be generated for all of these reuseIdentifiers: DuplicateCellView, duplicateCellView",
   ]
   
   func testLoggedWarnings() {


### PR DESCRIPTION
Read the project file instead of traversing over disk. We use Xcode.swift for this purpose.

This PR also makes it possible to pass in a output directory where the generated file is outputted. So this also covers PR #59. :)