### PR TITLE
The productName in the pbxproj doesn't seem to get updated. Matching with name instead. Requires Xcode.swift update.

### DIFF
--- a/R.swift/types.swift
+++ b/R.swift/types.swift
@@ -339,7 +339,7 @@ struct Xcodeproj {
   func resourceURLsForTarget(targetName: String, pathResolver: Path -> NSURL) throws -> [NSURL] {
     // Look for target in project file
     let allTargets = projectFile.project.targets
-    guard let target = allTargets.filter({ $0.productName == targetName }).first else {
+    guard let target = allTargets.filter({ $0.name == targetName }).first else {
       let availableTargets = allTargets.map { $0.productName }.joinWithSeparator(", ")
       throw ResourceParsingError.ParsingFailed("Target '\(targetName)' not found in project file, available targets are: \(availableTargets)")
     }

--- a/R.swift/types.swift
+++ b/R.swift/types.swift
@@ -340,7 +340,7 @@ struct Xcodeproj {
     // Look for target in project file
     let allTargets = projectFile.project.targets
     guard let target = allTargets.filter({ $0.name == targetName }).first else {
-      let availableTargets = allTargets.map { $0.productName }.joinWithSeparator(", ")
+      let availableTargets = allTargets.map { $0.name }.joinWithSeparator(", ")
       throw ResourceParsingError.ParsingFailed("Target '\(targetName)' not found in project file, available targets are: \(availableTargets)")
     }
 


### PR DESCRIPTION
I noticed this today while building another target in the same project
as the original target I’ve been using R.swift with:

If I run `rswift`, I get an error saying that there is not a target
with the name matching the target I’m running, then it prints the
targets name:

```
[R.swift] Target ‘MyAppStaging’ not found in project file, available
targets are: MyApp, MyAppTests, MyApp  // This second 'MyApp' is MyAppStaging
```

Which is obviously not the case because I’m running said target.

I took a look into the `.pbxproj` and found that `My App Staging`’s
`productName` was still set to the `productName` that I had duplicated
it from (My App).

I checked Xcode build settings several times but couldn’t see why this
was the case. It seems that Xcode doesn’t really use this value and
only sets it when creating the project? (I have the build settings
product name set for this Staging target, but it’s not reflected here
by `productName`…).

It is, however, reflected by `name`, so targets should be matched
against name instead.

This commit requires an update on the Xcode.swift module:

https://github.com/mac-cain13/Xcode.swift/pull/1