### PR TITLE
Support tvOS in podspec

### DIFF
--- a/R.swift.podspec
+++ b/R.swift.podspec
@@ -20,6 +20,7 @@ Pod::Spec.new do |s|
   s.social_media_url   = "https://twitter.com/mac_cain13"
 
   s.ios.deployment_target = '7.0'
+  s.tvos.deployment_target = '9.0'
   s.watchos.deployment_target = '1.0'
 
   s.source       = { :http => "https://github.com/mac-cain13/R.swift/releases/download/v0.10.0/rswift-0.10.0.zip" }


### PR DESCRIPTION
I think this is all that's needed to add tvOS support to R.swift (https://github.com/mac-cain13/R.swift/issues/105).

I also looked into adding Mac OSX support (https://github.com/mac-cain13/R.swift/issues/102), but that's a bit more work.
R.swift is currently hardcoded to using UIKit, that would need to be made dynamic to also support AppKit.