### PR TITLE
Feature/load from correct bundle

### DIFF
--- a/R.swift/func.swift
+++ b/R.swift/func.swift
@@ -134,7 +134,7 @@ func storyboardStructAndFunctionFromStoryboards(storyboards: [Storyboard]) -> (S
 }
 
 func storyboardStructForStoryboard(storyboard: Storyboard) -> Struct {
-  let instanceVars = [Var(isStatic: true, name: "instance", type: Type._UIStoryboard, getter: "return UIStoryboard(name: \"\(storyboard.name)\", bundle: nil)")]
+  let instanceVars = [Var(isStatic: true, name: "instance", type: Type._UIStoryboard, getter: "return UIStoryboard(name: \"\(storyboard.name)\", bundle: _R.hostingBundle)")]
 
   let initialViewControllerVar = [storyboard.initialViewController
     .map { (vc) -> Var in

--- a/R.swift/func.swift
+++ b/R.swift/func.swift
@@ -87,7 +87,7 @@ func readResourceFile(fileURL: NSURL) -> String? {
 func imageStructFromAssetFolders(assetFolders: [AssetFolder], andImages images: [Image]) -> Struct {
   let assetFolderImageVars = assetFolders
     .flatMap { $0.imageAssets }
-    .map { Var(isStatic: true, name: $0, type: Type._UIImage.asOptional(), getter: "return UIImage(named: \"\($0)\")") }
+    .map { Var(isStatic: true, name: $0, type: Type._UIImage.asOptional(), getter: "return UIImage(named: \"\($0)\", inBundle: _R.hostingBundle, compatibleWithTraitCollection: nil)") }
 
   let uniqueImages = images
     .groupBy { $0.name }
@@ -95,7 +95,7 @@ func imageStructFromAssetFolders(assetFolders: [AssetFolder], andImages images: 
     .flatMap { $0.first }
 
   let imageVars = uniqueImages
-    .map { Var(isStatic: true, name: $0.name, type: Type._UIImage.asOptional(), getter: "return UIImage(named: \"\($0.name)\")") }
+    .map { Var(isStatic: true, name: $0.name, type: Type._UIImage.asOptional(), getter: "return UIImage(named: \"\($0.name)\", inBundle: _R.hostingBundle, compatibleWithTraitCollection: nil)") }
 
   let vars = (assetFolderImageVars + imageVars)
     .groupUniquesAndDuplicates { $0.callName }

--- a/R.swift/func.swift
+++ b/R.swift/func.swift
@@ -216,7 +216,7 @@ func nibStructForNib(nib: Nib) -> Struct {
     isStatic: false,
     name: "instance",
     type: Type._UINib,
-    getter: "return UINib.init(nibName: \"\(nib.name)\", bundle: nil)"
+    getter: "return UINib.init(nibName: \"\(nib.name)\", bundle: _R.hostingBundle)"
   )
 
   let instantiateFunc = Function(

--- a/R.swift/func.swift
+++ b/R.swift/func.swift
@@ -332,5 +332,5 @@ func resourceStructFromResourceFiles(resourceFiles: [ResourceFile]) -> Struct {
 
 func varFromResourceFile(resourceFile: ResourceFile) -> Var {
   let pathExtensionOrNilString = resourceFile.pathExtension ?? "nil"
-  return Var(isStatic: true, name: resourceFile.fullname, type: Type._NSURL.asOptional(), getter: "return NSBundle.mainBundle().URLForResource(\"\(resourceFile.filename)\", withExtension: \"\(pathExtensionOrNilString)\")")
+  return Var(isStatic: true, name: resourceFile.fullname, type: Type._NSURL.asOptional(), getter: "return _R.hostingBundle?.URLForResource(\"\(resourceFile.filename)\", withExtension: \"\(pathExtensionOrNilString)\")")
 }

--- a/R.swift/input.swift
+++ b/R.swift/input.swift
@@ -25,6 +25,11 @@ private let targetOption = Option(
   numberOfParameters: 1,
   helpDescription: "Target the R-file should be generated for, if non given R.swift will use the environment variable TARGET_NAME."
 )
+private let bundleIdentifierOption = Option(
+  trigger: .Long("bundleIdentifier"),
+  numberOfParameters: 1,
+  helpDescription: "Bundle identifier the R-file should be generated for, if non given R.swift will use the environment variable PRODUCT_BUNDLE_IDENTIFIER."
+)
 private let buildProductsDirOption = Option(
   trigger: .Long("buildProductsDir"), 
   numberOfParameters: 1, 
@@ -60,6 +65,7 @@ struct CallInformation {
 
   let xcodeprojURL: NSURL
   let targetName: String
+  let bundleIdentifier: String
 
   private let buildProductsDirURL: NSURL
   private let developerDirURL: NSURL
@@ -102,6 +108,8 @@ struct CallInformation {
       xcodeprojURL = NSURL(fileURLWithPath: xcodeprojPath)
 
       targetName = try getFirstArgumentForOption(targetOption, defaultValue: environment["TARGET_NAME"])
+
+      bundleIdentifier = try getFirstArgumentForOption(bundleIdentifierOption, defaultValue: environment["PRODUCT_BUNDLE_IDENTIFIER"])
 
       let buildProductsDirPath = try getFirstArgumentForOption(buildProductsDirOption, defaultValue: environment["BUILT_PRODUCTS_DIR"])
       buildProductsDirURL = NSURL(fileURLWithPath: buildProductsDirPath)

--- a/R.swift/main.swift
+++ b/R.swift/main.swift
@@ -17,7 +17,7 @@ do {
 
   let resources = Resources(resourceURLs: resourceURLs, fileManager: NSFileManager.defaultManager())
 
-  let (internalStruct, externalStruct) = generateResourceStructsWithResources(resources)
+  let (internalStruct, externalStruct) = generateResourceStructsWithResources(resources, bundleIdentifier: callInformation.bundleIdentifier)
 
   let fileContents = [
     Header,

--- a/R.swift/processing.swift
+++ b/R.swift/processing.swift
@@ -44,7 +44,7 @@ struct Resources {
   }
 }
 
-func generateResourceStructsWithResources(resources: Resources) -> (Struct, Struct) {
+func generateResourceStructsWithResources(resources: Resources, bundleIdentifier: String) -> (Struct, Struct) {
   // Generate resource file contents
   let storyboardStructAndFunction = storyboardStructAndFunctionFromStoryboards(resources.storyboards)
 
@@ -72,7 +72,9 @@ func generateResourceStructsWithResources(resources: Resources) -> (Struct, Stru
     type: Type(name: "_R"),
     implements: [],
     lets: [],
-    vars: [],
+    vars: [
+      Var(isStatic: true, name: "hostingBundle", type: Type._NSBundle.asOptional(), getter: "return NSBundle(identifier: \"\(bundleIdentifier)\")")
+    ],
     functions: [],
     structs: [
       nibStructs.intern

--- a/R.swift/types.swift
+++ b/R.swift/types.swift
@@ -35,6 +35,7 @@ struct Type: CustomStringConvertible, Equatable, Hashable {
   static let _UINib = Type(name: "UINib")
   static let _UIView = Type(name: "UIView")
   static let _UIImage = Type(name: "UIImage")
+  static let _NSBundle = Type(name: "NSBundle")
   static let _NSIndexPath = Type(name: "NSIndexPath")
   static let _UITableView = Type(name: "UITableView")
   static let _UITableViewCell = Type(name: "UITableViewCell")

--- a/R.swift/values.swift
+++ b/R.swift/values.swift
@@ -69,7 +69,7 @@ let NibUIViewControllerExtension = Extension(
       parameters: [
         Function.Parameter(name: "nib", type: Type(name: "NibResource"))
       ],
-      body: "self.init(nibName: nib.name, bundle: nil)"
+      body: "self.init(nibName: nib.name, bundle: _R.hostingBundle)"
     ) as Func
   ]
 )


### PR DESCRIPTION
R.swift now "knows" for what bundle the resource file is generated and will use this information when loading images/files/storyboards and other resources. This should make you able to use R.swift for a library for example.

This should fix #31.