### PR TITLE
Use availability check and iOS7 fallback for UIImage

### DIFF
--- a/Documentation/QandA.md
+++ b/Documentation/QandA.md
@@ -23,3 +23,8 @@ During installation you add R.swift as a Build phase to your target, basically t
 - Every time you build R.swift will be runned
 - It takes a look at your Xcode project file and inspects all resources linked with the target currently build
 - It generates a `R.generated.swift` file that contains a struct with types references to all resources
+
+## Does R.swift work for iOS7?
+
+R.swift does also work for iOS7, with one caveat though: 
+- Images can only be loaded from the main bundle

--- a/R.swift/func.swift
+++ b/R.swift/func.swift
@@ -87,15 +87,14 @@ func readResourceFile(fileURL: NSURL) -> String? {
 func imageStructFromAssetFolders(assetFolders: [AssetFolder], andImages images: [Image]) -> Struct {
   let assetFolderImageVars = assetFolders
     .flatMap { $0.imageAssets }
-    .map { Var(isStatic: true, name: $0, type: Type._UIImage.asOptional(), getter: "return UIImage(named: \"\($0)\", inBundle: _R.hostingBundle, compatibleWithTraitCollection: nil)") }
-
+    .map { Var(isStatic: true, name: $0, type: Type._UIImage.asOptional(), getter: "if #available(iOS 8.0, *) { return UIImage(named: \"\($0)\", inBundle: _R.hostingBundle, compatibleWithTraitCollection: nil) } else { return UIImage(named: \"\($0)\") }") }
   let uniqueImages = images
     .groupBy { $0.name }
     .values
     .flatMap { $0.first }
 
   let imageVars = uniqueImages
-    .map { Var(isStatic: true, name: $0.name, type: Type._UIImage.asOptional(), getter: "return UIImage(named: \"\($0.name)\", inBundle: _R.hostingBundle, compatibleWithTraitCollection: nil)") }
+    .map { Var(isStatic: true, name: $0.name, type: Type._UIImage.asOptional(), getter: "if #available(iOS 8.0, *) { return UIImage(named: \"\($0.name)\", inBundle: _R.hostingBundle, compatibleWithTraitCollection: nil) } else { return UIImage(named: \"\($0.name)\") }") }
 
   let vars = (assetFolderImageVars + imageVars)
     .groupUniquesAndDuplicates { $0.callName }

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Runtime validation with [`R.validate()`](Documentation/Examples.md#storyboards):
 - [Why should I choose R.swift over alternative X or Y?](Documentation/QandA.md#why-should-i-choose-rswift-over-alternative-x-or-y)
 - [How does R.swift work?](Documentation/QandA.md#how-does-rswift-work)
 - [Why was R.swift created?](Documentation/QandA.md#why-was-rswift-created)
+- [Does R.swift work for iOS7?](Documentation/QandA.md#does_rswift_work_for_ios7)
 
 ## Installation
 


### PR DESCRIPTION
`UIImage.init(named:inBundle:compatibleWithTraitCollection:)` is only available in iOS 8.0 and later.

By using swifts new `#available(iOS 8.0, *)` check and `UIImage(named:<name>)` as fallback, R.swift can also be used for on iOS7. 

There's one caveat though: `UIImage(named:<name>)` can only load images from the main bundle. I think that this is OK (and it's documented in the Q&A) because this is mostly relevant when using dynamic frameworks (e.g. in 3rd party swift dependencies) which is not supported on iOS7 anyway. 