### PR TITLE
Support for font with uppercase file extensions

### DIFF
--- a/R.swift/types.swift
+++ b/R.swift/types.swift
@@ -419,7 +419,7 @@ struct Font {
   let name: String
 
   init(url: NSURL) throws {
-    guard let pathExtension = url.pathExtension where FontExtensions.contains(pathExtension) else {
+    guard let pathExtension = url.pathExtension?.lowercaseString where FontExtensions.contains(pathExtension) else {
       throw ResourceParsingError.UnsupportedExtension(givenExtension: url.pathExtension, supportedExtensions: FontExtensions)
     }
 


### PR DESCRIPTION
This is a minor patch to let R.swift list fonts that have uppercase file name and extensions (e.g. `.TFF` instead of `.ttd`).