### PR TITLE
Remove R.file.someFile() returning String?

### DIFF
--- a/Documentation/Examples.md
+++ b/Documentation/Examples.md
@@ -192,6 +192,6 @@ let jsonPath = NSBundle.mainBundle().pathForResource("seed-data", withExtension:
 
 *With R.swift*
 ```swift
-let jsonURL: NSURL? = R.file.seedDataJson()
-let jsonPath: String? = R.file.seedDataJson()
+let jsonURL = R.file.seedDataJson()
+let jsonPath = NSBundle.mainBundle().pathForResource(R.file.seedDataJson)
 ```

--- a/R.swift/Generators/ResourceFileGenerator.swift
+++ b/R.swift/Generators/ResourceFileGenerator.swift
@@ -45,17 +45,6 @@ struct ResourceFileGenerator: Generator {
               doesThrow: false,
               returnType: Type._NSURL.asOptional(),
               body: "let fileResource = R.file.\(sanitizedSwiftName($0.fullname))\nreturn fileResource.bundle?.URLForResource(fileResource)"
-            ),
-            Function(
-              isStatic: true,
-              name: $0.fullname,
-              generics: nil,
-              parameters: [
-                Function.Parameter(name: "_", type: Type._Void)
-              ],
-              doesThrow: false,
-              returnType: Type._String.asOptional(),
-              body: "let fileResource = R.file.\(sanitizedSwiftName($0.fullname))\nreturn fileResource.bundle?.pathForResource(fileResource)"
             )
           ]
         },


### PR DESCRIPTION
Resolves 'ambiguous use of file' described in https://github.com/mac-cain13/R.swift/issues/150
Since most uses of `R.file.someFile()` seems to be NSURL, the other overload of String was removed.

The path String is still available via `R.file.someFile.path()`.