### PR TITLE
Don't generate code for empty identifier

### DIFF
--- a/R.swift/Generators/ImageGenerator.swift
+++ b/R.swift/Generators/ImageGenerator.swift
@@ -63,8 +63,7 @@ struct ImageGenerator: Generator {
     let groupedFunctions = allFunctions.groupBySwiftNames { $0.callName }
 
     for (sanitizedName, duplicates) in groupedFunctions.duplicates {
-      let names = duplicates.map { $0.name }.sort().joinWithSeparator(", ")
-      warn("Skipping \(duplicates.count) images because symbol '\(sanitizedName)' would be generated for all of these images: \(names)")
+      warn("Skipping \(duplicates.count) images because symbol '\(sanitizedName)' would be generated for all of these images: \(duplicates.joinWithSeparator(", "))")
     }
 
     let imageLets = groupedFunctions

--- a/R.swift/Generators/ImageGenerator.swift
+++ b/R.swift/Generators/ImageGenerator.swift
@@ -59,15 +59,16 @@ struct ImageGenerator: Generator {
         )
       }
 
-    let functions = (assetFolderImageFunctions + imageFunctions)
-      .groupUniquesAndDuplicates { $0.callName }
+    let allFunctions = assetFolderImageFunctions + imageFunctions
+    let groupedFunctions = allFunctions.groupBySwiftNames { $0.callName }
 
-    for duplicate in functions.duplicates {
-      let names = duplicate.map { $0.name }.sort().joinWithSeparator(", ")
-      warn("Skipping \(duplicate.count) images because symbol '\(duplicate.first!.callName)' would be generated for all of these images: \(names)")
+    for (sanitizedName, duplicates) in groupedFunctions.duplicates {
+      let names = duplicates.map { $0.name }.sort().joinWithSeparator(", ")
+      warn("Skipping \(duplicates.count) images because symbol '\(sanitizedName)' would be generated for all of these images: \(names)")
     }
 
-    let imageLets = functions.uniques
+    let imageLets = groupedFunctions
+      .uniques
       .map {
         Let(
           isStatic: true,
@@ -82,7 +83,7 @@ struct ImageGenerator: Generator {
       implements: [],
       typealiasses: [],
       properties: imageLets.map(anyProperty),
-      functions: functions.uniques,
+      functions: groupedFunctions.uniques,
       structs: []
     )
   }

--- a/R.swift/Generators/ImageGenerator.swift
+++ b/R.swift/Generators/ImageGenerator.swift
@@ -66,6 +66,14 @@ struct ImageGenerator: Generator {
       warn("Skipping \(duplicates.count) images because symbol '\(sanitizedName)' would be generated for all of these images: \(duplicates.joinWithSeparator(", "))")
     }
 
+    let empties = groupedFunctions.empties
+    if let empty = empties.first where empties.count == 1 {
+      warn("Skipping 1 image because no swift identifier can be generated for image: \(empty)")
+    }
+    else if empties.count > 1 {
+      warn("Skipping \(empties.count) images because no swift identifier can be generated for all of these images: \(empties.joinWithSeparator(", "))")
+    }
+
     let imageLets = groupedFunctions
       .uniques
       .map {

--- a/R.swift/Generators/NibGenerator.swift
+++ b/R.swift/Generators/NibGenerator.swift
@@ -39,8 +39,7 @@ struct NibGenerator: Generator {
     let groupedNibs = nibs.groupBySwiftNames { $0.name }
 
     for (name, duplicates) in groupedNibs.duplicates {
-      let names = duplicates.map { $0.name }.sort().joinWithSeparator(", ")
-      warn("Skipping \(duplicates.count) xibs because symbol '\(name)' would be generated for all of these xibs: \(names)")
+      warn("Skipping \(duplicates.count) xibs because symbol '\(name)' would be generated for all of these xibs: \(duplicates.joinWithSeparator(", "))")
     }
 
     internalStruct = Struct(

--- a/R.swift/Generators/NibGenerator.swift
+++ b/R.swift/Generators/NibGenerator.swift
@@ -36,11 +36,11 @@ struct NibGenerator: Generator {
   let internalStruct: Struct?
 
   init(nibs: [Nib]) {
-    let groupedNibs = nibs.groupUniquesAndDuplicates { sanitizedSwiftName($0.name) }
+    let groupedNibs = nibs.groupBySwiftNames { $0.name }
 
-    for duplicate in groupedNibs.duplicates {
-      let names = duplicate.map { $0.name }.sort().joinWithSeparator(", ")
-      warn("Skipping \(duplicate.count) xibs because symbol '\(sanitizedSwiftName(duplicate.first!.name))' would be generated for all of these xibs: \(names)")
+    for (name, duplicates) in groupedNibs.duplicates {
+      let names = duplicates.map { $0.name }.sort().joinWithSeparator(", ")
+      warn("Skipping \(duplicates.count) xibs because symbol '\(name)' would be generated for all of these xibs: \(names)")
     }
 
     internalStruct = Struct(

--- a/R.swift/Generators/NibGenerator.swift
+++ b/R.swift/Generators/NibGenerator.swift
@@ -42,6 +42,14 @@ struct NibGenerator: Generator {
       warn("Skipping \(duplicates.count) xibs because symbol '\(name)' would be generated for all of these xibs: \(duplicates.joinWithSeparator(", "))")
     }
 
+    let empties = groupedNibs.empties
+    if let empty = empties.first where empties.count == 1 {
+      warn("Skipping 1 xib because no swift identifier can be generated for xib: \(empty)")
+    }
+    else if empties.count > 1 {
+      warn("Skipping \(empties.count) xibs because no swift identifier can be generated for all of these xibs: \(empties.joinWithSeparator(", "))")
+    }
+
     internalStruct = Struct(
         type: Type(module: .Host, name: "nib"),
         implements: [],

--- a/R.swift/Generators/ResourceFileGenerator.swift
+++ b/R.swift/Generators/ResourceFileGenerator.swift
@@ -16,8 +16,7 @@ struct ResourceFileGenerator: Generator {
     let groupedResourceFiles = resourceFiles.groupBySwiftNames { $0.fullname }
 
     for (name, duplicates) in groupedResourceFiles.duplicates {
-      let names = duplicates.map { $0.fullname }.sort().joinWithSeparator(", ")
-      warn("Skipping \(duplicates.count) resource files because symbol '\(name)' would be generated for all of these files: \(names)")
+      warn("Skipping \(duplicates.count) resource files because symbol '\(name)' would be generated for all of these files: \(duplicates.joinWithSeparator(", "))")
     }
 
     externalStruct = Struct(

--- a/R.swift/Generators/ResourceFileGenerator.swift
+++ b/R.swift/Generators/ResourceFileGenerator.swift
@@ -13,12 +13,11 @@ struct ResourceFileGenerator: Generator {
   let internalStruct: Struct? = nil
 
   init(resourceFiles: [ResourceFile]) {
-    let groupedResourceFiles = resourceFiles
-      .groupUniquesAndDuplicates { sanitizedSwiftName($0.fullname) }
+    let groupedResourceFiles = resourceFiles.groupBySwiftNames { $0.fullname }
 
-    for duplicate in groupedResourceFiles.duplicates {
-      let names = duplicate.map { $0.fullname }.sort().joinWithSeparator(", ")
-      warn("Skipping \(duplicate.count) resource files because symbol '\(sanitizedSwiftName(duplicate.first!.fullname))' would be generated for all of these files: \(names)")
+    for (name, duplicates) in groupedResourceFiles.duplicates {
+      let names = duplicates.map { $0.fullname }.sort().joinWithSeparator(", ")
+      warn("Skipping \(duplicates.count) resource files because symbol '\(name)' would be generated for all of these files: \(names)")
     }
 
     externalStruct = Struct(

--- a/R.swift/Generators/ResourceFileGenerator.swift
+++ b/R.swift/Generators/ResourceFileGenerator.swift
@@ -19,6 +19,14 @@ struct ResourceFileGenerator: Generator {
       warn("Skipping \(duplicates.count) resource files because symbol '\(name)' would be generated for all of these files: \(duplicates.joinWithSeparator(", "))")
     }
 
+    let empties = groupedResourceFiles.empties
+    if let empty = empties.first where empties.count == 1 {
+      warn("Skipping 1 resource file because no swift identifier can be generated for file: \(empty)")
+    }
+    else if empties.count > 1 {
+      warn("Skipping \(empties.count) resource files because no swift identifier can be generated for all of these files: \(empties.joinWithSeparator(", "))")
+    }
+
     externalStruct = Struct(
       type: Type(module: .Host, name: "file"),
       implements: [],

--- a/R.swift/Generators/ReuseIdentifierGenerator.swift
+++ b/R.swift/Generators/ReuseIdentifierGenerator.swift
@@ -18,11 +18,11 @@ struct ReuseIdentifierGenerator: Generator {
       .values
       .flatMap { $0.first }
 
-    let groupedReusables = deduplicatedReusables.groupUniquesAndDuplicates { sanitizedSwiftName($0.identifier) }
+    let groupedReusables = deduplicatedReusables.groupBySwiftNames { $0.identifier }
 
-    for duplicate in groupedReusables.duplicates {
-      let names = duplicate.map { $0.identifier }.sort().joinWithSeparator(", ")
-      warn("Skipping \(duplicate.count) reuseIdentifiers because symbol '\(sanitizedSwiftName(duplicate.first!.identifier))' would be generated for all of these reuseIdentifiers: \(names)")
+    for (name, duplicates) in groupedReusables.duplicates {
+      let names = duplicates.map { $0.identifier }.sort().joinWithSeparator(", ")
+      warn("Skipping \(duplicates.count) reuseIdentifiers because symbol '\(name)' would be generated for all of these reuseIdentifiers: \(names)")
     }
 
     let reuseIdentifierProperties = groupedReusables

--- a/R.swift/Generators/ReuseIdentifierGenerator.swift
+++ b/R.swift/Generators/ReuseIdentifierGenerator.swift
@@ -21,8 +21,7 @@ struct ReuseIdentifierGenerator: Generator {
     let groupedReusables = deduplicatedReusables.groupBySwiftNames { $0.identifier }
 
     for (name, duplicates) in groupedReusables.duplicates {
-      let names = duplicates.map { $0.identifier }.sort().joinWithSeparator(", ")
-      warn("Skipping \(duplicates.count) reuseIdentifiers because symbol '\(name)' would be generated for all of these reuseIdentifiers: \(names)")
+      warn("Skipping \(duplicates.count) reuseIdentifiers because symbol '\(name)' would be generated for all of these reuseIdentifiers: \(duplicates.joinWithSeparator(", "))")
     }
 
     let reuseIdentifierProperties = groupedReusables

--- a/R.swift/Generators/ReuseIdentifierGenerator.swift
+++ b/R.swift/Generators/ReuseIdentifierGenerator.swift
@@ -24,6 +24,14 @@ struct ReuseIdentifierGenerator: Generator {
       warn("Skipping \(duplicates.count) reuseIdentifiers because symbol '\(name)' would be generated for all of these reuseIdentifiers: \(duplicates.joinWithSeparator(", "))")
     }
 
+    let empties = groupedReusables.empties
+    if let empty = empties.first where empties.count == 1 {
+      warn("Skipping 1 reuseIdentifier because no swift identifier can be generated for reuseIdentifier: \(empty)")
+    }
+    else if empties.count > 1 {
+      warn("Skipping \(empties.count) reuseIdentifiers because no swift identifier can be generated for all of these reuseIdentifiers: \(empties.joinWithSeparator(", "))")
+    }
+
     let reuseIdentifierProperties = groupedReusables
       .uniques
       .map(ReuseIdentifierGenerator.letFromReusable)

--- a/R.swift/Generators/SegueGenerator.swift
+++ b/R.swift/Generators/SegueGenerator.swift
@@ -50,6 +50,14 @@ struct SegueGenerator: Generator {
         warn("Skipping \(duplicates.count) segues for '\(sourceType)' because symbol '\(name)' would be generated for all of these segues, but with a different destination or segue type: \(duplicates.joinWithSeparator(", "))")
       }
 
+      let empties = gropuedSeguesWithInfo.empties
+      if let empty = empties.first where empties.count == 1 {
+        warn("Skipping 1 segue for '\(sourceType)' because no swift identifier can be generated for segue: \(empty)")
+      }
+      else if empties.count > 1 {
+        warn("Skipping \(empties.count) segues for '\(sourceType)' because no swift identifier can be generated for all of these segues: \(empties.joinWithSeparator(", "))")
+      }
+
       let sts = gropuedSeguesWithInfo
         .uniques
         .groupBy { $0.sourceType }

--- a/R.swift/Generators/SegueGenerator.swift
+++ b/R.swift/Generators/SegueGenerator.swift
@@ -44,13 +44,13 @@ struct SegueGenerator: Generator {
     var structs: [Struct] = []
 
     for (sourceType, seguesBySourceType) in deduplicatedSeguesWithInfo.groupBy({ $0.sourceType }) {
-      let gropuedSeguesWithInfo = seguesBySourceType.groupBySwiftNames { $0.segue.identifier }
+      let groupedSeguesWithInfo = seguesBySourceType.groupBySwiftNames { $0.segue.identifier }
 
-      for (name, duplicates) in gropuedSeguesWithInfo.duplicates {
+      for (name, duplicates) in groupedSeguesWithInfo.duplicates {
         warn("Skipping \(duplicates.count) segues for '\(sourceType)' because symbol '\(name)' would be generated for all of these segues, but with a different destination or segue type: \(duplicates.joinWithSeparator(", "))")
       }
 
-      let empties = gropuedSeguesWithInfo.empties
+      let empties = groupedSeguesWithInfo.empties
       if let empty = empties.first where empties.count == 1 {
         warn("Skipping 1 segue for '\(sourceType)' because no swift identifier can be generated for segue: \(empty)")
       }
@@ -58,7 +58,7 @@ struct SegueGenerator: Generator {
         warn("Skipping \(empties.count) segues for '\(sourceType)' because no swift identifier can be generated for all of these segues: \(empties.joinWithSeparator(", "))")
       }
 
-      let sts = gropuedSeguesWithInfo
+      let sts = groupedSeguesWithInfo
         .uniques
         .groupBy { $0.sourceType }
         .values

--- a/R.swift/Generators/SegueGenerator.swift
+++ b/R.swift/Generators/SegueGenerator.swift
@@ -41,19 +41,24 @@ struct SegueGenerator: Generator {
       .values
       .flatMap { $0.first }
 
-    let groupedSeguesWithInfo = deduplicatedSeguesWithInfo
-      .groupUniquesAndDuplicates { "\(sanitizedSwiftName($0.segue.identifier))|\($0.sourceType)" }
+    var structs: [Struct] = []
 
-    for duplicate in groupedSeguesWithInfo.duplicates {
-      let anySegueWithInfo = duplicate.first!
-      let names = duplicate.map { $0.segue.identifier }.sort().joinWithSeparator(", ")
-      warn("Skipping \(duplicate.count) segues for '\(anySegueWithInfo.sourceType)' because symbol '\(sanitizedSwiftName(anySegueWithInfo.segue.identifier))' would be generated for all of these segues, but with a different destination or segue type: \(names)")
+    for (sourceType, seguesBySourceType) in deduplicatedSeguesWithInfo.groupBy({ $0.sourceType }) {
+      let gropuedSeguesWithInfo = seguesBySourceType.groupBySwiftNames { $0.segue.identifier }
+
+      for (name, duplicates) in gropuedSeguesWithInfo.duplicates {
+        let names = duplicates.map { $0.segue.identifier }.sort().joinWithSeparator(", ")
+        warn("Skipping \(duplicates.count) segues for '\(sourceType)' because symbol '\(name)' would be generated for all of these segues, but with a different destination or segue type: \(names)")
+      }
+
+      let sts = gropuedSeguesWithInfo
+        .uniques
+        .groupBy { $0.sourceType }
+        .values
+        .flatMap(SegueGenerator.seguesWithInfoForSourceTypeToStruct)
+
+      structs = structs + sts
     }
-
-    let structs = groupedSeguesWithInfo.uniques
-      .groupBy { $0.sourceType }
-      .values
-      .flatMap(SegueGenerator.seguesWithInfoForSourceTypeToStruct)
 
     externalStruct = Struct(
       type: Type(module: .Host, name: "segue"),

--- a/R.swift/Generators/SegueGenerator.swift
+++ b/R.swift/Generators/SegueGenerator.swift
@@ -47,8 +47,7 @@ struct SegueGenerator: Generator {
       let gropuedSeguesWithInfo = seguesBySourceType.groupBySwiftNames { $0.segue.identifier }
 
       for (name, duplicates) in gropuedSeguesWithInfo.duplicates {
-        let names = duplicates.map { $0.segue.identifier }.sort().joinWithSeparator(", ")
-        warn("Skipping \(duplicates.count) segues for '\(sourceType)' because symbol '\(name)' would be generated for all of these segues, but with a different destination or segue type: \(names)")
+        warn("Skipping \(duplicates.count) segues for '\(sourceType)' because symbol '\(name)' would be generated for all of these segues, but with a different destination or segue type: \(duplicates.joinWithSeparator(", "))")
       }
 
       let sts = gropuedSeguesWithInfo

--- a/R.swift/Generators/StoryboardGenerator.swift
+++ b/R.swift/Generators/StoryboardGenerator.swift
@@ -13,11 +13,11 @@ struct StoryboardGenerator: Generator {
   let internalStruct: Struct?
 
   init(storyboards: [Storyboard]) {
-    let groupedStoryboards = storyboards.groupUniquesAndDuplicates { sanitizedSwiftName($0.name) }
+    let groupedStoryboards = storyboards.groupBySwiftNames { $0.name }
 
-    for duplicate in groupedStoryboards.duplicates {
-      let names = duplicate.map { $0.name }.sort().joinWithSeparator(", ")
-      warn("Skipping \(duplicate.count) storyboards because symbol '\(sanitizedSwiftName(duplicate.first!.name))' would be generated for all of these storyboards: \(names)")
+    for (name, duplicates) in groupedStoryboards.duplicates {
+      let names = duplicates.map { $0.name }.sort().joinWithSeparator(", ")
+      warn("Skipping \(duplicates.count) storyboards because symbol '\(name)' would be generated for all of these storyboards: \(names)")
     }
 
     let storyboardStructs = groupedStoryboards

--- a/R.swift/Generators/StoryboardGenerator.swift
+++ b/R.swift/Generators/StoryboardGenerator.swift
@@ -19,6 +19,14 @@ struct StoryboardGenerator: Generator {
       warn("Skipping \(duplicates.count) storyboards because symbol '\(name)' would be generated for all of these storyboards: \(duplicates.joinWithSeparator(", "))")
     }
 
+    let empties = groupedStoryboards.empties
+    if let empty = empties.first where empties.count == 1 {
+      warn("Skipping 1 storyboard because no swift identifier can be generated for storyboard: \(empty)")
+    }
+    else if empties.count > 1 {
+      warn("Skipping \(empties.count) storyboards because no swift identifier can be generated for all of these storyboards: \(empties.joinWithSeparator(", "))")
+    }
+
     let storyboardStructs = groupedStoryboards
       .uniques
       .map(StoryboardGenerator.storyboardStructForStoryboard)

--- a/R.swift/Generators/StoryboardGenerator.swift
+++ b/R.swift/Generators/StoryboardGenerator.swift
@@ -16,8 +16,7 @@ struct StoryboardGenerator: Generator {
     let groupedStoryboards = storyboards.groupBySwiftNames { $0.name }
 
     for (name, duplicates) in groupedStoryboards.duplicates {
-      let names = duplicates.map { $0.name }.sort().joinWithSeparator(", ")
-      warn("Skipping \(duplicates.count) storyboards because symbol '\(name)' would be generated for all of these storyboards: \(names)")
+      warn("Skipping \(duplicates.count) storyboards because symbol '\(name)' would be generated for all of these storyboards: \(duplicates.joinWithSeparator(", "))")
     }
 
     let storyboardStructs = groupedStoryboards

--- a/R.swift/Util/SanitizedSwiftName.swift
+++ b/R.swift/Util/SanitizedSwiftName.swift
@@ -32,18 +32,20 @@ func sanitizedSwiftName(name: String, lowercaseFirstCharacter: Bool = true) -> S
 
 struct SwiftNameGroups<T> {
   let uniques: [T]
-  let duplicates: [(String, [T])]
-  let empties: [T]
+  let duplicates: [(String, [String])] // Identifiers that result in duplicate Swift names
+  let empties: [String] // Identifiers that result in empty swift names
 }
 
 extension SequenceType {
   func groupBySwiftNames(identifierSelector: Generator.Element -> String) -> SwiftNameGroups<Generator.Element> {
     var groupedBy = groupBy { sanitizedSwiftName(identifierSelector($0)) }
-    let empties = groupedBy[""]
+    let empties = groupedBy[""]?.map { identifierSelector($0) }
     groupedBy[""] = nil
 
     let uniques = groupedBy.values.filter { $0.count == 1 }.flatten()
-    let duplicates = groupedBy.filter { $0.1.count > 1 }
+    let duplicates = groupedBy
+      .filter { $0.1.count > 1 }
+      .map { ($0.0, $0.1.map(identifierSelector).sort()) }
 
     return SwiftNameGroups(uniques: Array(uniques), duplicates: duplicates, empties: empties ?? [])
   }

--- a/R.swift/Util/SanitizedSwiftName.swift
+++ b/R.swift/Util/SanitizedSwiftName.swift
@@ -42,12 +42,12 @@ extension SequenceType {
     let empties = groupedBy[""]?.map { "'\(identifierSelector($0))'" }.sort()
     groupedBy[""] = nil
 
-    let uniques = groupedBy.values.filter { $0.count == 1 }.flatten()
+    let uniques = Array(groupedBy.values.filter { $0.count == 1 }.flatten())
     let duplicates = groupedBy
       .filter { $0.1.count > 1 }
       .map { ($0.0, $0.1.map(identifierSelector).sort()) }
 
-    return SwiftNameGroups(uniques: Array(uniques), duplicates: duplicates, empties: empties ?? [])
+    return SwiftNameGroups(uniques: uniques, duplicates: duplicates, empties: empties ?? [])
   }
 }
 

--- a/R.swift/Util/SanitizedSwiftName.swift
+++ b/R.swift/Util/SanitizedSwiftName.swift
@@ -33,13 +33,13 @@ func sanitizedSwiftName(name: String, lowercaseFirstCharacter: Bool = true) -> S
 struct SwiftNameGroups<T> {
   let uniques: [T]
   let duplicates: [(String, [String])] // Identifiers that result in duplicate Swift names
-  let empties: [String] // Identifiers that result in empty swift names
+  let empties: [String] // Identifiers (wrapped in quotes) that result in empty swift names
 }
 
 extension SequenceType {
   func groupBySwiftNames(identifierSelector: Generator.Element -> String) -> SwiftNameGroups<Generator.Element> {
     var groupedBy = groupBy { sanitizedSwiftName(identifierSelector($0)) }
-    let empties = groupedBy[""]?.map { identifierSelector($0) }
+    let empties = groupedBy[""]?.map { "'\(identifierSelector($0))'" }.sort()
     groupedBy[""] = nil
 
     let uniques = groupedBy.values.filter { $0.count == 1 }.flatten()

--- a/R.swift/Util/UtilExtensions.swift
+++ b/R.swift/Util/UtilExtensions.swift
@@ -11,16 +11,6 @@ import Foundation
 
 // MARK: Array operations
 
-extension SequenceType {
-  func groupUniquesAndDuplicates<U: Hashable>(keySelector: Generator.Element -> U) -> (uniques: [Generator.Element], duplicates: [[Generator.Element]]) {
-    let groupedBy = Array(groupBy(keySelector).values)
-    let uniques = groupedBy.filter { $0.count == 1 }.reduce([], combine: +)
-    let duplicates = groupedBy.filter { $0.count > 1 }
-
-    return (uniques: uniques, duplicates: duplicates)
-  }
-}
-
 extension SequenceType where Generator.Element : CustomStringConvertible {
   func joinWithSeparator(separator: String) -> String {
     return map { $0.description }.joinWithSeparator(separator)

--- a/ResourceApp/ResourceApp.xcodeproj/project.pbxproj
+++ b/ResourceApp/ResourceApp.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		D5F05D461BB52078003AE55E /* duplicateJson in Resources */ = {isa = PBXBuildFile; fileRef = D5F05D451BB52078003AE55E /* duplicateJson */; };
 		D5F05D481BB520B1003AE55E /* FilesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5F05D471BB520B1003AE55E /* FilesTests.swift */; };
 		D5FAD9091B63B05700ECE230 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D55C6CC61B5D757300301B0D /* Images.xcassets */; };
+		E22070771C92E137007A090B /* WhitespaceReuseIdentifer.xib in Resources */ = {isa = PBXBuildFile; fileRef = E22070761C92E137007A090B /* WhitespaceReuseIdentifer.xib */; };
 		E49A92E1DBC6CCB05867DDB6 /* Pods_ResourceApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AEC5C6D68E1E8337CC9568C1 /* Pods_ResourceApp.framework */; };
 /* End PBXBuildFile section */
 
@@ -124,6 +125,7 @@
 		D5F05D431BB52063003AE55E /* Duplicate.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = Duplicate.json; sourceTree = "<group>"; };
 		D5F05D451BB52078003AE55E /* duplicateJson */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = duplicateJson; sourceTree = "<group>"; };
 		D5F05D471BB520B1003AE55E /* FilesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FilesTests.swift; sourceTree = "<group>"; };
+		E22070761C92E137007A090B /* WhitespaceReuseIdentifer.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = WhitespaceReuseIdentifer.xib; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -228,6 +230,7 @@
 				D55C6CBB1B5D757300301B0D /* Supporting Files */,
 				D5B799841C1B8DB6009EA901 /* Settings.bundle */,
 				C378DD791C68C2BF003598B8 /* SupplementaryElement.xib */,
+				E22070761C92E137007A090B /* WhitespaceReuseIdentifer.xib */,
 			);
 			path = ResourceApp;
 			sourceTree = "<group>";
@@ -406,6 +409,7 @@
 				D5E513BE1B8E111A0035ECAA /* GdyBkltter1911.ttf in Resources */,
 				D51E60C61BB1E600004BB376 /* User@white@2x.png in Resources */,
 				D51E60C11BB13626004BB376 /* Colors.jpg in Resources */,
+				E22070771C92E137007A090B /* WhitespaceReuseIdentifer.xib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ResourceApp/ResourceApp/WhitespaceReuseIdentifer.xib
+++ b/ResourceApp/ResourceApp/WhitespaceReuseIdentifer.xib
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9532" systemVersion="15D21" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9530"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier=" " id="yTq-Bk-xQX">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+            <autoresizingMask key="autoresizingMask"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="yTq-Bk-xQX" id="xgh-Yx-L0w">
+                <rect key="frame" x="0.0" y="0.0" width="320" height="43"/>
+                <autoresizingMask key="autoresizingMask"/>
+            </tableViewCellContentView>
+            <point key="canvasLocation" x="306" y="385"/>
+        </tableViewCell>
+    </objects>
+</document>


### PR DESCRIPTION
Implements https://github.com/mac-cain13/R.swift/issues/137

No longer generate (invalid) code for sanitized Swift identifiers that are an empty string. Instead print a warning. 

The code for printing warnings is a bit repetitive, and can be cleaned up. This falls under https://github.com/mac-cain13/R.swift/issues/136, I think.