### PR TITLE
Fix warnings in Xcode 7.3

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - R.swift.Library (1.1.0)
+  - R.swift.Library (2.0.0)
 
 DEPENDENCIES:
   - R.swift.Library (from `./R.swift.Library`)
@@ -9,6 +9,6 @@ EXTERNAL SOURCES:
     :path: ./R.swift.Library
 
 SPEC CHECKSUMS:
-  R.swift.Library: 775f3086e07313ed1a1dfddca8418317f5a87397
+  R.swift.Library: 9f4b2d12040daa1ffe336d8f7e1574f73721fd01
 
 COCOAPODS: 0.39.0

--- a/R.swift.xcworkspace/contents.xcworkspacedata
+++ b/R.swift.xcworkspace/contents.xcworkspacedata
@@ -5,7 +5,7 @@
       location = "container:R.swift.xcodeproj">
    </FileRef>
    <FileRef
-      location = "group:/Users/mathijs/Development/R.swift/R.swift.Library/R.swift.Library.xcodeproj">
+      location = "group:R.swift.Library/R.swift.Library.xcodeproj">
    </FileRef>
    <FileRef
       location = "group:ResourceApp/ResourceApp.xcodeproj">

--- a/R.swift/ResourceTypes/Nib.swift
+++ b/R.swift/ResourceTypes/Nib.swift
@@ -55,7 +55,7 @@ private class NibParserDelegate: NSObject, NSXMLParserDelegate {
 
     default:
       if isObjectsTagOpened {
-        levelSinceObjectsTagOpened++;
+        levelSinceObjectsTagOpened += 1;
 
         if let rootView = viewWithAttributes(attributeDict, elementName: elementName)
           where levelSinceObjectsTagOpened == 1 && ignoredRootViewElements.filter({ $0 == elementName }).count == 0 {
@@ -76,7 +76,7 @@ private class NibParserDelegate: NSObject, NSXMLParserDelegate {
 
     default:
       if isObjectsTagOpened {
-        levelSinceObjectsTagOpened--;
+        levelSinceObjectsTagOpened -= 1;
       }
     }
   }

--- a/R.swift/input.swift
+++ b/R.swift/input.swift
@@ -157,20 +157,24 @@ struct CallInformation {
   }
 }
 
-private func getFirstArgumentFromOptionData(options: [Option:[String]], helpString: String)(_ option: Option, defaultValue: String?) throws -> String {
-  guard let result = options[option]?.first ?? defaultValue else {
-    throw InputParsingError.MissingOption(error: "Missing option: \(option) ", helpString: helpString)
-  }
-
-  return result
+private func getFirstArgumentFromOptionData(options: [Option:[String]], helpString: String) -> (_: Option, defaultValue: String?) throws -> String {
+    return { (option, defaultValue) in
+        guard let result = options[option]?.first ?? defaultValue else {
+            throw InputParsingError.MissingOption(error: "Missing option: \(option) ", helpString: helpString)
+        }
+        
+        return result
+    }
 }
 
-func pathResolverWithSourceTreeFolderToURLConverter(URLForSourceTreeFolder: SourceTreeFolder -> NSURL)(path: Path) -> NSURL {
-  switch path {
-  case let .Absolute(absolutePath):
-    return NSURL(fileURLWithPath: absolutePath)
-  case let .RelativeTo(sourceTreeFolder, relativePath):
-    let sourceTreeURL = URLForSourceTreeFolder(sourceTreeFolder)
-    return sourceTreeURL.URLByAppendingPathComponent(relativePath)
-  }
+func pathResolverWithSourceTreeFolderToURLConverter(URLForSourceTreeFolder: SourceTreeFolder -> NSURL) -> (path: Path) -> NSURL {
+    return { path in
+        switch path {
+        case let .Absolute(absolutePath):
+            return NSURL(fileURLWithPath: absolutePath)
+        case let .RelativeTo(sourceTreeFolder, relativePath):
+            let sourceTreeURL = URLForSourceTreeFolder(sourceTreeFolder)
+            return sourceTreeURL.URLByAppendingPathComponent(relativePath)
+        }
+    }
 }

--- a/ResourceApp/ResourceApp.xcodeproj/project.pbxproj
+++ b/ResourceApp/ResourceApp.xcodeproj/project.pbxproj
@@ -681,10 +681,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
@@ -701,10 +698,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = ResourceAppTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "nl.mathijskadijk.$(PRODUCT_NAME:rfc1034identifier)";


### PR DESCRIPTION
Issues fixed:
- The workspace reference to the R.swift.Library project was an absolute path instead of a relative path.
- The ResourceAppTests target still had leftover Framework search paths from Xcode 6
- Swift 2.2 deprecated ++/-- operators
- Swift 2.2 deprecated function currying syntax

Let me know if you want me to bump the podspec version.