### PR TITLE
Project wide indentation settings

### DIFF
--- a/R.swift.xcodeproj/project.pbxproj
+++ b/R.swift.xcodeproj/project.pbxproj
@@ -236,7 +236,10 @@
 				D5C4227E1B711FDF004EA9B9 /* R.swiftTests */,
 				D5EA0DF51A3DF45600FFEBC4 /* Products */,
 			);
+			indentWidth = 2;
 			sourceTree = "<group>";
+			tabWidth = 2;
+			usesTabs = 0;
 		};
 		D5EA0DF51A3DF45600FFEBC4 /* Products */ = {
 			isa = PBXGroup;

--- a/ResourceApp/ResourceApp.xcodeproj/project.pbxproj
+++ b/ResourceApp/ResourceApp.xcodeproj/project.pbxproj
@@ -244,7 +244,10 @@
 				6BD8864A6B6559C4D6F93D81 /* Pods */,
 				065D32753EEB6C7AE2FA201F /* Frameworks */,
 			);
+			indentWidth = 2;
 			sourceTree = "<group>";
+			tabWidth = 2;
+			usesTabs = 0;
 		};
 		D55C6CB91B5D757300301B0D /* Products */ = {
 			isa = PBXGroup;


### PR DESCRIPTION
Sets the indentation style used in R.swift in the project file. So contributors don't have to change their Xcode settings.