### PR TITLE
Close view controller on scene, because we need the extra objects

### DIFF
--- a/R.swift/ResourceTypes/Storyboard.swift
+++ b/R.swift/ResourceTypes/Storyboard.swift
@@ -176,7 +176,7 @@ private class StoryboardParserDelegate: NSObject, NSXMLParserDelegate {
   }
 
   @objc func parser(parser: NSXMLParser, didEndElement elementName: String, namespaceURI: String?, qualifiedName qName: String?) {
-    if let currentViewController = currentViewController where elementName == currentViewController.0 {
+    if let currentViewController = currentViewController where elementName == "scene" {
       viewControllers.append(currentViewController.1)
       self.currentViewController = nil
     }


### PR DESCRIPTION
<img width="1512" alt="screen shot 2016-05-26 at 2 17 35 pm" src="https://cloud.githubusercontent.com/assets/1057756/15565364/a405fdc4-234c-11e6-85b6-1d0394d89c0a.png">

When the segue is not **exactly** in the view controller, but in the scene, we should generate those segues as well.

This might not be a very good fix, but it seems to be the easiest.