### PR TITLE
Feature/fully qualified types

### DIFF
--- a/R.swift/Generators/ColorGenerator.swift
+++ b/R.swift/Generators/ColorGenerator.swift
@@ -55,7 +55,7 @@ struct ColorGenerator: Generator {
       isStatic: true,
       name: SwiftIdentifier(name: name),
       typeDefinition: .inferred(Type.ColorResource),
-      value: "ColorResource(name: \"\(name)\", red: \(color.redComponent), green: \(color.greenComponent), blue: \(color.blueComponent), alpha: \(color.alphaComponent))"
+      value: "Rswift.ColorResource(name: \"\(name)\", red: \(color.redComponent), green: \(color.greenComponent), blue: \(color.blueComponent), alpha: \(color.alphaComponent))"
     )
   }
 
@@ -74,7 +74,7 @@ struct ColorGenerator: Generator {
       ],
       doesThrow: false,
       returnType: Type._UIColor,
-      body: "return UIColor(red: \(color.redComponent), green: \(color.greenComponent), blue: \(color.blueComponent), alpha: \(color.alphaComponent))"
+      body: "return UIKit.UIColor(red: \(color.redComponent), green: \(color.greenComponent), blue: \(color.blueComponent), alpha: \(color.alphaComponent))"
     )
   }
 }

--- a/R.swift/Generators/FontGenerator.swift
+++ b/R.swift/Generators/FontGenerator.swift
@@ -22,7 +22,7 @@ struct FontGenerator: Generator {
         isStatic: true,
         name: SwiftIdentifier(name: $0.name),
         typeDefinition: .inferred(Type.FontResource),
-        value: "FontResource(fontName: \"\($0.name)\")"
+        value: "Rswift.FontResource(fontName: \"\($0.name)\")"
       )
     }
 
@@ -48,7 +48,7 @@ struct FontGenerator: Generator {
       ],
       doesThrow: false,
       returnType: Type._UIFont.asOptional(),
-      body: "return UIFont(resource: \(SwiftIdentifier(name: font.name)), size: size)"
+      body: "return UIKit.UIFont(resource: \(SwiftIdentifier(name: font.name)), size: size)"
     )
   }
 }

--- a/R.swift/Generators/ImageGenerator.swift
+++ b/R.swift/Generators/ImageGenerator.swift
@@ -35,7 +35,7 @@ struct ImageGenerator: Generator {
           isStatic: true,
           name: SwiftIdentifier(name: name),
           typeDefinition: .inferred(Type.ImageResource),
-          value: "\(Type.ImageResource.name)(bundle: _R.hostingBundle, name: \"\(name)\")"
+          value: "Rswift.ImageResource(bundle: _R.hostingBundle, name: \"\(name)\")"
         )
       }
 
@@ -66,7 +66,7 @@ struct ImageGenerator: Generator {
       ],
       doesThrow: false,
       returnType: Type._UIImage.asOptional(),
-      body: "return \(Type._UIImage.name)(resource: R.image.\(SwiftIdentifier(name: name)), compatibleWith: traitCollection)"
+      body: "return UIKit.UIImage(resource: R.image.\(SwiftIdentifier(name: name)), compatibleWith: traitCollection)"
     )
   }
 }

--- a/R.swift/Generators/NibGenerator.swift
+++ b/R.swift/Generators/NibGenerator.swift
@@ -79,7 +79,7 @@ struct NibGenerator: Generator {
       ],
       doesThrow: false,
       returnType: Type._UINib,
-      body: "return UINib(resource: R.nib.\(SwiftIdentifier(name: nib.name)))"
+      body: "return UIKit.UINib(resource: R.nib.\(SwiftIdentifier(name: nib.name)))"
     )
   }
 

--- a/R.swift/Generators/ResourceFileGenerator.swift
+++ b/R.swift/Generators/ResourceFileGenerator.swift
@@ -42,7 +42,7 @@ struct ResourceFileGenerator: Generator {
           isStatic: true,
           name: SwiftIdentifier(name: $0.fullname),
           typeDefinition: .inferred(Type.FileResource),
-          value: "FileResource(bundle: _R.hostingBundle, name: \"\($0.filename)\", pathExtension: \"\($0.pathExtension)\")"
+          value: "Rswift.FileResource(bundle: _R.hostingBundle, name: \"\($0.filename)\", pathExtension: \"\($0.pathExtension)\")"
         )
     }
   }

--- a/R.swift/Generators/ResourceGenerator.swift
+++ b/R.swift/Generators/ResourceGenerator.swift
@@ -75,7 +75,7 @@ func generateResourceStructs(with resources: Resources, bundleIdentifier: String
     externalStructs.append(Struct(
         accessModifier: .Private,
         type: Type(module: .host, name: "intern"),
-        implements: [TypePrinter(type: Type.Validatable, style: .fullyQualified)],
+        implements: [TypePrinter(type: Type.Validatable)],
         typealiasses: [],
         properties: [],
         functions: [

--- a/R.swift/Generators/ReuseIdentifierGenerator.swift
+++ b/R.swift/Generators/ReuseIdentifierGenerator.swift
@@ -42,7 +42,7 @@ struct ReuseIdentifierGenerator: Generator {
       isStatic: true,
       name: SwiftIdentifier(name: reusable.identifier),
       typeDefinition: .specified(Type.ReuseIdentifier.withGenericArgs([reusable.type])),
-      value: "\(Type.ReuseIdentifier.name)(identifier: \"\(reusable.identifier)\")"
+      value: "Rswift.ReuseIdentifier(identifier: \"\(reusable.identifier)\")"
     )
   }
 }

--- a/R.swift/Generators/SegueGenerator.swift
+++ b/R.swift/Generators/SegueGenerator.swift
@@ -108,7 +108,7 @@ struct SegueGenerator: Generator {
         isStatic: true,
         name: SwiftIdentifier(name: segueWithInfo.segue.identifier),
         typeDefinition: .specified(type),
-        value: "StoryboardSegueIdentifier(identifier: \"\(segueWithInfo.segue.identifier)\")"
+        value: "Rswift.StoryboardSegueIdentifier(identifier: \"\(segueWithInfo.segue.identifier)\")"
       )
     }
 
@@ -129,7 +129,7 @@ struct SegueGenerator: Generator {
         returnType: Type.TypedStoryboardSegueInfo
           .asOptional()
           .withGenericArgs([segueWithInfo.segue.type, segueWithInfo.sourceType, segueWithInfo.destinationType]),
-        body: "return TypedStoryboardSegueInfo(segueIdentifier: R.segue.\(SwiftIdentifier(name: sourceType.description)).\(SwiftIdentifier(name: segueWithInfo.segue.identifier)), segue: segue)"
+        body: "return Rswift.TypedStoryboardSegueInfo(segueIdentifier: R.segue.\(SwiftIdentifier(name: sourceType.description)).\(SwiftIdentifier(name: segueWithInfo.segue.identifier)), segue: segue)"
       )
     }
 

--- a/R.swift/Generators/StoryboardGenerator.swift
+++ b/R.swift/Generators/StoryboardGenerator.swift
@@ -158,7 +158,7 @@ struct StoryboardGenerator: Generator {
         body: validateLines.joined(separator: "\n")
       )
       functions.append(validateFunction)
-      implements.append(TypePrinter(type: Type.Validatable, style: .fullyQualified))
+      implements.append(TypePrinter(type: Type.Validatable))
     }
 
     // Return

--- a/R.swift/Generators/StoryboardGenerator.swift
+++ b/R.swift/Generators/StoryboardGenerator.swift
@@ -49,7 +49,7 @@ struct StoryboardGenerator: Generator {
           ],
           doesThrow: false,
           returnType: Type._UIStoryboard,
-          body: "return UIStoryboard(resource: R.storyboard.\(struct_.type.name))"
+          body: "return UIKit.UIStoryboard(resource: R.storyboard.\(struct_.type.name))"
         )
       }
 
@@ -129,7 +129,7 @@ struct StoryboardGenerator: Generator {
           ],
           doesThrow: false,
           returnType: vc.type.asOptional(),
-          body: "return UIStoryboard(resource: self).instantiateViewController(withResource: \(resource.name))"
+          body: "return UIKit.UIStoryboard(resource: self).instantiateViewController(withResource: \(resource.name))"
         )
       }
       .forEach { functions.append($0) }
@@ -137,7 +137,7 @@ struct StoryboardGenerator: Generator {
     // Validation
     let validateImagesLines = Set(storyboard.usedImageIdentifiers)
       .map {
-        "if UIImage(named: \"\($0)\") == nil { throw Rswift.ValidationError(description: \"[R.swift] Image named '\($0)' is used in storyboard '\(storyboard.name)', but couldn't be loaded.\") }"
+        "if UIKit.UIImage(named: \"\($0)\") == nil { throw Rswift.ValidationError(description: \"[R.swift] Image named '\($0)' is used in storyboard '\(storyboard.name)', but couldn't be loaded.\") }"
       }
     let validateViewControllersLines = storyboard.viewControllers
       .flatMap { vc in

--- a/R.swift/Generators/StringsGenerator.swift
+++ b/R.swift/Generators/StringsGenerator.swift
@@ -168,7 +168,7 @@ struct StringsGenerator: Generator {
       isStatic: true,
       name: SwiftIdentifier(name: values.key),
       typeDefinition: .inferred(Type.StringResource),
-      value: "StringResource(key: \"\(escapedKey)\", tableName: \"\(values.tableName)\", bundle: _R.hostingBundle, locales: [\(locales)], comment: nil)"
+      value: "Rswift.StringResource(key: \"\(escapedKey)\", tableName: \"\(values.tableName)\", bundle: _R.hostingBundle, locales: [\(locales)], comment: nil)"
     )
   }
 

--- a/R.swift/SwiftTypes/CodeGenerators/TypePrinter.swift
+++ b/R.swift/SwiftTypes/CodeGenerators/TypePrinter.swift
@@ -9,13 +9,7 @@
 import Foundation
 
 struct TypePrinter: SwiftCodeConverible, UsedTypesProvider {
-  enum Style {
-    case fullyQualified
-    case withoutModule
-  }
-
   let type: Type
-  let style: Style
 
   var usedTypes: [UsedType] {
     return type.usedTypes
@@ -32,22 +26,15 @@ struct TypePrinter: SwiftCodeConverible, UsedTypesProvider {
       withoutModule = "\(type.name)\(optionalString)"
     }
 
-    switch (style, type.module) {
-    case (.fullyQualified, let .custom(moduleName)):
+    if case let .custom(name: moduleName) = type.module {
       return "\(moduleName).\(withoutModule)"
-    case (.fullyQualified, _), (.withoutModule, _):
+    } else {
       return withoutModule
     }
   }
 
   init(type: Type) {
     self.type = type
-    self.style = .withoutModule
-  }
-
-  init(type: Type, style: Style) {
-    self.type = type
-    self.style = style
   }
 }
 

--- a/R.swift/Util/Struct+ChildValidation.swift
+++ b/R.swift/Util/Struct+ChildValidation.swift
@@ -28,7 +28,7 @@ extension Struct {
 
     var outputStruct = self
     outputStruct.structs = childStructs
-    outputStruct.implements.append(TypePrinter(type: Type.Validatable, style: .fullyQualified))
+    outputStruct.implements.append(TypePrinter(type: Type.Validatable))
     outputStruct.functions.append(
       Function(
         isStatic: true,


### PR DESCRIPTION
This PR solves #262. We now will always print the fully qualified name to prevent name clashes as described in the referenced issue.