### PR TITLE
Color assets for Xcode 9

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -5,7 +5,7 @@ project 'ResourceApp/ResourceApp'
 
 abstract_target 'Shared' do
 
-  pod 'R.swift.Library', :git => 'git@github.com:mac-cain13/R.swift.Library.git' # for CI builds
+  pod 'R.swift.Library', :git => 'git@github.com:mac-cain13/R.swift.Library.git', :branch => 'color-asset-resource' # for CI builds
   # pod 'R.swift.Library', :path => '../R.swift.Library' # for development
 
   target 'ResourceApp' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -3,22 +3,23 @@ PODS:
   - SWRevealViewController (2.3.0)
 
 DEPENDENCIES:
-  - R.swift.Library (from `git@github.com:mac-cain13/R.swift.Library.git`)
+  - R.swift.Library (from `git@github.com:mac-cain13/R.swift.Library.git`, branch `color-asset-resource`)
   - SWRevealViewController
 
 EXTERNAL SOURCES:
   R.swift.Library:
+    :branch: color-asset-resource
     :git: git@github.com:mac-cain13/R.swift.Library.git
 
 CHECKOUT OPTIONS:
   R.swift.Library:
-    :commit: 594965c3c1d42d9a4390eec3ecf159ab8210cb78
+    :commit: ce03cde8d0edd9658c36a971a0bc8fde390a8b43
     :git: git@github.com:mac-cain13/R.swift.Library.git
 
 SPEC CHECKSUMS:
   R.swift.Library: fbdec16c9802ad104fc1ba53415dc190e6ec5c73
   SWRevealViewController: 6d3fd97f70112fd7cef9de14df4260eacce4c63a
 
-PODFILE CHECKSUM: 57ee52d68f28b860809cf246049602c22acf39d2
+PODFILE CHECKSUM: 29323947ca32a3f3344cd006a8b44a36ffb886f0
 
 COCOAPODS: 1.2.1

--- a/ResourceApp/ResourceApp.xcodeproj/project.pbxproj
+++ b/ResourceApp/ResourceApp.xcodeproj/project.pbxproj
@@ -80,6 +80,7 @@
 		E22070771C92E137007A090B /* WhitespaceReuseIdentifer.xib in Resources */ = {isa = PBXBuildFile; fileRef = E22070761C92E137007A090B /* WhitespaceReuseIdentifer.xib */; };
 		E22A62091E8AE788009B7F9F /* Display P3.clr in Resources */ = {isa = PBXBuildFile; fileRef = E22A62081E8AE788009B7F9F /* Display P3.clr */; };
 		E24720CE1C96B71B00DF291D /* ColorsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E24720CD1C96B71B00DF291D /* ColorsTests.swift */; };
+		E2562CD61EE70C68007D8938 /* Media.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E2562CD51EE70C68007D8938 /* Media.xcassets */; };
 		E2762AC01CCCDFDA0009BCAA /* Settings.stringsdict in Resources */ = {isa = PBXBuildFile; fileRef = E2762AC21CCCDFDA0009BCAA /* Settings.stringsdict */; };
 		E2762AE01CCE62CC0009BCAA /* Generic.stringsdict in Resources */ = {isa = PBXBuildFile; fileRef = E2762ADF1CCE62CC0009BCAA /* Generic.stringsdict */; };
 		E29693581CAD64B500401D53 /* __FILE__ in Resources */ = {isa = PBXBuildFile; fileRef = E29693571CAD64B500401D53 /* __FILE__ */; };
@@ -196,6 +197,7 @@
 		E22070761C92E137007A090B /* WhitespaceReuseIdentifer.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = WhitespaceReuseIdentifer.xib; sourceTree = "<group>"; };
 		E22A62081E8AE788009B7F9F /* Display P3.clr */ = {isa = PBXFileReference; lastKnownFileType = file.bplist; path = "Display P3.clr"; sourceTree = "<group>"; };
 		E24720CD1C96B71B00DF291D /* ColorsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ColorsTests.swift; sourceTree = "<group>"; };
+		E2562CD51EE70C68007D8938 /* Media.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Media.xcassets; sourceTree = "<group>"; };
 		E2762AC11CCCDFDA0009BCAA /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = Base; path = Base.lproj/Settings.stringsdict; sourceTree = "<group>"; };
 		E2762AC31CCCDFE10009BCAA /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = nl; path = nl.lproj/Settings.stringsdict; sourceTree = "<group>"; };
 		E2762ADF1CCE62CC0009BCAA /* Generic.stringsdict */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.stringsdict; path = Generic.stringsdict; sourceTree = "<group>"; };
@@ -342,6 +344,7 @@
 				D55C6CBF1B5D757300301B0D /* FirstViewController.swift */,
 				D5CBCE481B7682B800C5D96B /* MyViewController.swift */,
 				D55C6CC11B5D757300301B0D /* SecondViewController.swift */,
+				E2562CD51EE70C68007D8938 /* Media.xcassets */,
 				D55C6CC61B5D757300301B0D /* Images.xcassets */,
 				CCBC9CB81EC4809D002F3D0E /* Images2.xcassets */,
 				D5AD5C9C1B7A901F00A8B96C /* ADuplicateCellView.xib */,
@@ -634,6 +637,7 @@
 				D5AD5C9B1B7A8F4300A8B96C /* CellView.xib in Resources */,
 				D5159E9E1BBC33680013F52A /* Colors@2x.jpg in Resources */,
 				D5E513BA1B8E111A0035ECAA /* AveriaLibre-B.ttf in Resources */,
+				E2562CD61EE70C68007D8938 /* Media.xcassets in Resources */,
 				D50175BE1B5FEFD000DB8314 /* Secondary.storyboard in Resources */,
 				D5AD5C911B78FC0500A8B96C /* duplicate.xib in Resources */,
 				D575E25D1B766CD800C22F0B /* My View.xib in Resources */,

--- a/ResourceApp/ResourceApp.xcodeproj/project.pbxproj
+++ b/ResourceApp/ResourceApp.xcodeproj/project.pbxproj
@@ -78,7 +78,6 @@
 		E2156B6C1CC4293000F341DC /* Duplicate#.strings in Resources */ = {isa = PBXBuildFile; fileRef = E2156B6B1CC4293000F341DC /* Duplicate#.strings */; };
 		E2156B6E1CC42B6700F341DC /* @@.strings in Resources */ = {isa = PBXBuildFile; fileRef = E2156B6D1CC42B6700F341DC /* @@.strings */; };
 		E22070771C92E137007A090B /* WhitespaceReuseIdentifer.xib in Resources */ = {isa = PBXBuildFile; fileRef = E22070761C92E137007A090B /* WhitespaceReuseIdentifer.xib */; };
-		E22A62091E8AE788009B7F9F /* Display P3.clr in Resources */ = {isa = PBXBuildFile; fileRef = E22A62081E8AE788009B7F9F /* Display P3.clr */; };
 		E24720CE1C96B71B00DF291D /* ColorsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E24720CD1C96B71B00DF291D /* ColorsTests.swift */; };
 		E2562CD61EE70C68007D8938 /* Media.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E2562CD51EE70C68007D8938 /* Media.xcassets */; };
 		E2762AC01CCCDFDA0009BCAA /* Settings.stringsdict in Resources */ = {isa = PBXBuildFile; fileRef = E2762AC21CCCDFDA0009BCAA /* Settings.stringsdict */; };
@@ -87,8 +86,9 @@
 		E296935A1CAD64D100401D53 /* associatedtype in Resources */ = {isa = PBXBuildFile; fileRef = E29693591CAD64D100401D53 /* associatedtype */; };
 		E296935C1CAD666200401D53 /* #column in Resources */ = {isa = PBXBuildFile; fileRef = E296935B1CAD666200401D53 /* #column */; };
 		E2A10EF81CD13779006BFC63 /* RelativeToProject.xib in Resources */ = {isa = PBXBuildFile; fileRef = E2A10EF71CD13779006BFC63 /* RelativeToProject.xib */; };
+		E2CA68DE1EE74585009C4DB4 /* Display P3.clr in Resources */ = {isa = PBXBuildFile; fileRef = E22A62081E8AE788009B7F9F /* Display P3.clr */; };
+		E2CA68DF1EE74585009C4DB4 /* My R.swift colors.clr in Resources */ = {isa = PBXBuildFile; fileRef = E2F268B01C92BFE00093995D /* My R.swift colors.clr */; };
 		E2CD68671D7CADEA00BEBE59 /* hello.txt in Resources */ = {isa = PBXBuildFile; fileRef = E2CD68641D7CACC100BEBE59 /* hello.txt */; };
-		E2F268B11C92BFE00093995D /* My R.swift colors.clr in Resources */ = {isa = PBXBuildFile; fileRef = E2F268B01C92BFE00093995D /* My R.swift colors.clr */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -642,7 +642,6 @@
 				D5AD5C911B78FC0500A8B96C /* duplicate.xib in Resources */,
 				D575E25D1B766CD800C22F0B /* My View.xib in Resources */,
 				D5AD5C941B78FC4E00A8B96C /* Duplicate.xib in Resources */,
-				E22A62091E8AE788009B7F9F /* Display P3.clr in Resources */,
 				E2CD68671D7CADEA00BEBE59 /* hello.txt in Resources */,
 				D55C6CC51B5D757300301B0D /* Main.storyboard in Resources */,
 				E29693581CAD64B500401D53 /* __FILE__ in Resources */,
@@ -651,11 +650,11 @@
 				E2156B681CC41EB400F341DC /* Generic.strings in Resources */,
 				E296935A1CAD64D100401D53 /* associatedtype in Resources */,
 				D51E60C71BB1E600004BB376 /* User@white@3x.png in Resources */,
+				E2CA68DE1EE74585009C4DB4 /* Display P3.clr in Resources */,
 				D5B799851C1B8DB6009EA901 /* Settings.bundle in Resources */,
 				D5B799871C1B8DD2009EA901 /* Specials.storyboard in Resources */,
 				D5E513BD1B8E111A0035ECAA /* AveriaLibre.ttf in Resources */,
 				D52725FE1C4BB6BC0005C8D4 /* References.storyboard in Resources */,
-				E2F268B11C92BFE00093995D /* My R.swift colors.clr in Resources */,
 				E2156B6A1CC4292600F341DC /* Duplicate.strings in Resources */,
 				E2762AE01CCE62CC0009BCAA /* Generic.stringsdict in Resources */,
 				D5159EA01BBC37BC0013F52A /* Colors@3x.jpg in Resources */,
@@ -663,6 +662,7 @@
 				5D1AFAB11C858637003FE7AB /* Localizable.strings in Resources */,
 				D5E513BC1B8E111A0035ECAA /* AveriaLibre-L.ttf in Resources */,
 				D51E60C51BB1E600004BB376 /* User@white.png in Resources */,
+				E2CA68DF1EE74585009C4DB4 /* My R.swift colors.clr in Resources */,
 				D55C6CCA1B5D757300301B0D /* LaunchScreen.xib in Resources */,
 				C378DD7A1C68C2BF003598B8 /* SupplementaryElement.xib in Resources */,
 				E2762AC01CCCDFDA0009BCAA /* Settings.stringsdict in Resources */,

--- a/ResourceApp/ResourceApp/Images.xcassets/AppIcon.appiconset/Contents.json
+++ b/ResourceApp/ResourceApp/Images.xcassets/AppIcon.appiconset/Contents.json
@@ -88,6 +88,11 @@
       "idiom" : "ipad",
       "size" : "83.5x83.5",
       "scale" : "2x"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "size" : "1024x1024",
+      "scale" : "1x"
     }
   ],
   "info" : {

--- a/ResourceApp/ResourceApp/Images.xcassets/My Red.colorset/Contents.json
+++ b/ResourceApp/ResourceApp/Images.xcassets/My Red.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "red" : 0.8784313725,
+          "alpha" : 1,
+          "blue" : 0,
+          "green" : 0.4392156863
+        }
+      }
+    }
+  ]
+}

--- a/ResourceApp/ResourceApp/Media.xcassets/Contents.json
+++ b/ResourceApp/ResourceApp/Media.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/ResourceApp/ResourceApp/Media.xcassets/Folder/Contents.json
+++ b/ResourceApp/ResourceApp/Media.xcassets/Folder/Contents.json
@@ -1,0 +1,9 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "properties" : {
+    "provides-namespace" : true
+  }
+}

--- a/ResourceApp/ResourceApp/Media.xcassets/Folder/Not dupe.colorset/Contents.json
+++ b/ResourceApp/ResourceApp/Media.xcassets/Folder/Not dupe.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : 0.7860491071,
+          "alpha" : 1,
+          "blue" : 1,
+          "green" : 1
+        }
+      }
+    }
+  ]
+}

--- a/ResourceApp/ResourceApp/Media.xcassets/Keyboard Focus Indicator color.colorset/Contents.json
+++ b/ResourceApp/ResourceApp/Media.xcassets/Keyboard Focus Indicator color.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : 0.2313725490196079,
+          "alpha" : 1,
+          "blue" : 0.9882352941176471,
+          "green" : 0.6
+        }
+      }
+    }
+  ]
+}

--- a/ResourceApp/ResourceApp/Media.xcassets/My Red.colorset/Contents.json
+++ b/ResourceApp/ResourceApp/Media.xcassets/My Red.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "red" : 0.7215686274999999,
+          "alpha" : 1,
+          "blue" : 0.1019607843,
+          "green" : 0.02745098039
+        }
+      }
+    }
+  ]
+}

--- a/ResourceApp/ResourceApp/Media.xcassets/Not dupe.colorset/Contents.json
+++ b/ResourceApp/ResourceApp/Media.xcassets/Not dupe.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "red" : 1,
+          "alpha" : 1,
+          "blue" : 1,
+          "green" : 0.7767578125
+        }
+      }
+    }
+  ]
+}

--- a/ResourceApp/ResourceApp/Media.xcassets/Slightly transparant.colorset/Contents.json
+++ b/ResourceApp/ResourceApp/Media.xcassets/Slightly transparant.colorset/Contents.json
@@ -1,0 +1,18 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "extended-gray",
+        "components" : {
+          "white" : 0,
+          "alpha" : 0.4
+        }
+      }
+    }
+  ]
+}

--- a/ResourceApp/ResourceAppTests/ColorsTests.swift
+++ b/ResourceApp/ResourceAppTests/ColorsTests.swift
@@ -13,9 +13,9 @@ import XCTest
 class ColorsTests: XCTestCase {
 
   func testNoNilColors() {
-    XCTAssertNotNil(R.color.myRSwiftColors.allIsAOK())
-    XCTAssertNotNil(R.color.myRSwiftColors.severeError())
-    XCTAssertNotNil(R.color.myRSwiftColors.seeThroughGray)
+    XCTAssertNotNil(R.clr.myRSwiftColors.allIsAOK())
+    XCTAssertNotNil(R.clr.myRSwiftColors.severeError())
+    XCTAssertNotNil(R.clr.myRSwiftColors.seeThroughGray)
   }
 
 }

--- a/ResourceApp/ResourceAppTests/ResourceAppTests.swift
+++ b/ResourceApp/ResourceAppTests/ResourceAppTests.swift
@@ -28,6 +28,7 @@ class ResourceAppTests: XCTestCase {
     "warning: [R.swift] Skipping 2 view controllers because symbol 'validationClash' would be generated for all of these view controller identifiers: Validation clash, ValidationClash",
     "warning: [R.swift] Skipping 1 reuseIdentifier because no swift identifier can be generated for reuseIdentifier: ' '",
     "warning: [R.swift] Skipping 2 colors in palette 'My R.swift colors' because symbol 'black' would be generated for all of these colors: Black, Black?",
+    "warning: [R.swift] Skipping 2 colors because symbol 'myRed' would be generated for all of these colors: My Red, My Red",
 
     "warning: [R.swift] Skipping 2 strings files because symbol 'duplicate' would be generated for all of these files: Duplicate, Duplicate#",
     "warning: [R.swift] Skipping 1 strings file because no swift identifier can be generated for file: '@@'",

--- a/ResourceApp/ResourceAppTests/ResourceAppTests.swift
+++ b/ResourceApp/ResourceAppTests/ResourceAppTests.swift
@@ -59,10 +59,14 @@ class ResourceAppTests: XCTestCase {
 
     do {
       let logContent = try String(contentsOf: logURL)
-      let logLines = logContent.components(separatedBy: "\n")
+      let logLines = logContent.components(separatedBy: "\n").filter { !$0.isEmpty }
 
       for warning in expectedWarnings {
         XCTAssertTrue(logLines.contains(warning), "Warning is not logged: '\(warning)'")
+      }
+
+      for logLine in logLines {
+        XCTAssertTrue(expectedWarnings.contains(logLine), "Warning was not expected: '\(logLine)'")
       }
 
       XCTAssertEqual(logLines.count, expectedWarnings.count, "There are more/less warnings then expected")

--- a/Sources/RswiftCore/Generators/AggregatedStructGenerator.swift
+++ b/Sources/RswiftCore/Generators/AggregatedStructGenerator.swift
@@ -26,6 +26,7 @@ class AggregatedStructGenerator: StructGenerator {
       .reduce(StructGeneratorResultCollector()) { collector, result in collector.appending(result) }
 
     let externalStruct = Struct(
+      availables: [],
       comments: ["This `\(qualifiedName)` struct is generated and contains references to static resources."],
       accessModifier: externalAccessLevel,
       type: Type(module: .host, name: structName),
@@ -38,6 +39,7 @@ class AggregatedStructGenerator: StructGenerator {
     )
 
     let internalStruct = Struct(
+      availables: [],
       comments: [],
       accessModifier: externalAccessLevel,
       type: Type(module: .host, name: internalStructName),

--- a/Sources/RswiftCore/Generators/AssetSubfolders.swift
+++ b/Sources/RswiftCore/Generators/AssetSubfolders.swift
@@ -1,0 +1,37 @@
+//
+//  AssetSubfolders.swift
+//  Spectre
+//
+//  Created by Tom Lokhorst on 2017-06-06.
+//
+
+import Foundation
+
+struct AssetSubfolders {
+  let folders: [NamespacedAssetSubfolder]
+  let duplicates: [NamespacedAssetSubfolder]
+
+  init(all subfolders: [NamespacedAssetSubfolder], assetIdentifiers: [SwiftIdentifier]) {
+    var dict: [SwiftIdentifier: NamespacedAssetSubfolder] = [:]
+
+    for subfolder in subfolders {
+      let name = SwiftIdentifier(name: subfolder.name)
+      if let duplicate = dict[name] {
+        duplicate.subfolders += subfolder.subfolders
+        duplicate.imageAssets += subfolder.imageAssets
+      } else {
+        dict[name] = subfolder
+      }
+    }
+
+    self.folders = dict.values.filter { !assetIdentifiers.contains(SwiftIdentifier(name: $0.name)) }
+    self.duplicates = dict.values.filter { assetIdentifiers.contains(SwiftIdentifier(name: $0.name)) }
+  }
+
+  func printWarningsForDuplicates() {
+    for subfolder in duplicates {
+      warn("Skipping asset subfolder because symbol '\(subfolder.name)' would conflict with image: \(subfolder.name)")
+    }
+  }
+}
+

--- a/Sources/RswiftCore/Generators/ColorPaletteStructGenerator.swift
+++ b/Sources/RswiftCore/Generators/ColorPaletteStructGenerator.swift
@@ -24,6 +24,7 @@ struct ColorPaletteStructGenerator: ExternalOnlyStructGenerator {
     groupedPalettes.printWarningsForDuplicatesAndEmpties(source: "color palette", result: "file")
 
     return Struct(
+      availables: [],
       comments: ["This `\(qualifiedName)` struct is generated, and contains static references to \(palettes.count) color palettes."],
       accessModifier: externalAccessLevel,
       type: Type(module: .host, name: structName),
@@ -46,6 +47,7 @@ struct ColorPaletteStructGenerator: ExternalOnlyStructGenerator {
     groupedColors.printWarningsForDuplicatesAndEmpties(source: "color", container: "in palette '\(palette.filename)'", result: "color")
 
     return Struct(
+      availables: [],
       comments: ["This `\(qualifiedName)` struct is generated, and contains static references to \(groupedColors.uniques.count) colors."],
       accessModifier: externalAccessLevel,
       type: Type(module: .host, name: structName),

--- a/Sources/RswiftCore/Generators/ColorPaletteStructGenerator.swift
+++ b/Sources/RswiftCore/Generators/ColorPaletteStructGenerator.swift
@@ -1,5 +1,5 @@
 //
-//  ColorStructGenerator.swift
+//  ColorPaletteStructGenerator.swift
 //  R.swift
 //
 //  Created by Tom Lokhorst on 2016-03-13.
@@ -10,15 +10,15 @@
 import Foundation
 import AppKit.NSColor
 
-struct ColorStructGenerator: ExternalOnlyStructGenerator {
+struct ColorPaletteStructGenerator: ExternalOnlyStructGenerator {
   private let palettes: [ColorPalette]
 
-  init(colorPalettes palettes: [ColorPalette]) {
+  init(palettes: [ColorPalette]) {
     self.palettes = palettes
   }
 
   func generatedStruct(at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier) -> Struct {
-    let structName: SwiftIdentifier = "color"
+    let structName: SwiftIdentifier = "clr"
     let qualifiedName = prefix + structName
     let groupedPalettes = palettes.groupedBySwiftIdentifier { $0.filename }
     groupedPalettes.printWarningsForDuplicatesAndEmpties(source: "color palette", result: "file")

--- a/Sources/RswiftCore/Generators/ColorPaletteStructGenerator.swift
+++ b/Sources/RswiftCore/Generators/ColorPaletteStructGenerator.swift
@@ -72,8 +72,8 @@ struct ColorPaletteStructGenerator: ExternalOnlyStructGenerator {
       accessModifier: externalAccessLevel,
       isStatic: true,
       name: SwiftIdentifier(name: name),
-      typeDefinition: .inferred(Type.ColorResource),
-      value: "Rswift.ColorResource(name: \"\(name)\", red: \(color.redComponent), green: \(color.greenComponent), blue: \(color.blueComponent), alpha: \(color.alphaComponent))"
+      typeDefinition: .inferred(Type.ColorPaletteItemResource),
+      value: "Rswift.ColorPaletteItemResource(name: \"\(name)\", red: \(color.redComponent), green: \(color.greenComponent), blue: \(color.blueComponent), alpha: \(color.alphaComponent))"
     )
   }
 

--- a/Sources/RswiftCore/Generators/ColorStructGenerator.swift
+++ b/Sources/RswiftCore/Generators/ColorStructGenerator.swift
@@ -1,0 +1,156 @@
+//
+//  ColorStructGenerator.swift
+//  Spectre
+//
+//  Created by Tom Lokhorst on 2017-06-06.
+//
+
+import Foundation
+
+struct ColorStructGenerator: ExternalOnlyStructGenerator {
+  private let assetFolders: [AssetFolder]
+
+  init(assetFolders: [AssetFolder]) {
+    self.assetFolders = assetFolders
+  }
+
+  func generatedStruct(at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier) -> Struct {
+    let structName: SwiftIdentifier = "color"
+    let qualifiedName = prefix + structName
+    let assetFolderColorNames = assetFolders
+      .flatMap { $0.colorAssets }
+
+    let groupedColors = assetFolderColorNames.groupedBySwiftIdentifier { $0 }
+    groupedColors.printWarningsForDuplicatesAndEmpties(source: "color", result: "color")
+
+
+    let assetSubfolders = AssetSubfolders(
+      all: assetFolders.flatMap { $0.subfolders },
+      assetIdentifiers: groupedColors.uniques.map { SwiftIdentifier(name: $0) })
+
+    assetSubfolders.printWarningsForDuplicates()
+
+    let structs = assetSubfolders.folders
+      .map { $0.generatedColorStruct(at: externalAccessLevel, prefix: qualifiedName) }
+
+    let colorLets = groupedColors
+      .uniques
+      .map { name in
+        Let(
+          comments: ["Color `\(name)`."],
+          accessModifier: externalAccessLevel,
+          isStatic: true,
+          name: SwiftIdentifier(name: name),
+          typeDefinition: .inferred(Type.ColorResource),
+          value: "Rswift.ColorResource(bundle: R.hostingBundle, name: \"\(name)\")"
+        )
+    }
+
+    return Struct(
+      comments: ["This `\(qualifiedName)` struct is generated, and contains static references to \(colorLets.count) colors."],
+      accessModifier: externalAccessLevel,
+      type: Type(module: .host, name: structName),
+      implements: [],
+      typealiasses: [],
+      properties: colorLets,
+      functions: groupedColors.uniques.map { colorFunction(for: $0, at: externalAccessLevel, prefix: qualifiedName) },
+      structs: structs,
+      classes: []
+    )
+  }
+
+  private func colorFunction(for name: String, at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier) -> Function {
+    let structName = SwiftIdentifier(name: name)
+    let qualifiedName = prefix + structName
+
+    return Function(
+      comments: ["`UIColor(named: \"\(name)\", bundle: ..., traitCollection: ...)`"],
+      accessModifier: externalAccessLevel,
+      isStatic: true,
+      name: structName,
+      generics: nil,
+      parameters: [
+        Function.Parameter(
+          name: "compatibleWith",
+          localName: "traitCollection",
+          type: Type._UITraitCollection.asOptional(),
+          defaultValue: "nil"
+        )
+      ],
+      doesThrow: false,
+      returnType: Type._UIColor.asOptional(),
+      body: "return UIKit.UIColor(resource: \(qualifiedName), compatibleWith: traitCollection)"
+    )
+  }
+}
+
+private extension NamespacedAssetSubfolder {
+  func generatedColorStruct(at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier) -> Struct {
+    let allFunctions = colorAssets
+    let groupedFunctions = allFunctions.groupedBySwiftIdentifier { $0 }
+
+    groupedFunctions.printWarningsForDuplicatesAndEmpties(source: "color", result: "color")
+
+
+    let assetSubfolders = AssetSubfolders(
+      all: subfolders,
+      assetIdentifiers: allFunctions.map { SwiftIdentifier(name: $0) })
+
+    assetSubfolders.printWarningsForDuplicates()
+
+    let colorPath = resourcePath + (!path.isEmpty ? "/" : "")
+    let structName = SwiftIdentifier(name: self.name)
+    let qualifiedName = prefix + structName
+    let structs = assetSubfolders.folders
+      .map { $0.generatedColorStruct(at: externalAccessLevel, prefix: qualifiedName) }
+
+    let colorLets = groupedFunctions
+      .uniques
+      .map { name in
+        Let(
+          comments: ["Color `\(name)`."],
+          accessModifier: externalAccessLevel,
+          isStatic: true,
+          name: SwiftIdentifier(name: name),
+          typeDefinition: .inferred(Type.ColorResource),
+          value: "Rswift.ColorResource(bundle: R.hostingBundle, name: \"\(colorPath)\(name)\")"
+        )
+    }
+
+    return Struct(
+      comments: ["This `\(qualifiedName)` struct is generated, and contains static references to \(colorLets.count) colors."],
+      accessModifier: externalAccessLevel,
+      type: Type(module: .host, name: structName),
+      implements: [],
+      typealiasses: [],
+      properties: colorLets,
+      functions: groupedFunctions.uniques.map { colorFunction(for: $0, at: externalAccessLevel, prefix: qualifiedName) },
+      structs: structs,
+      classes: []
+    )
+  }
+
+  private func colorFunction(for name: String, at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier) -> Function {
+    let structName = SwiftIdentifier(name: name)
+    let qualifiedName = prefix + structName
+
+    return Function(
+      comments: ["`UIColor(named: \"\(name)\", bundle: ..., traitCollection: ...)`"],
+      accessModifier: externalAccessLevel,
+      isStatic: true,
+      name: structName,
+      generics: nil,
+      parameters: [
+        Function.Parameter(
+          name: "compatibleWith",
+          localName: "traitCollection",
+          type: Type._UITraitCollection.asOptional(),
+          defaultValue: "nil"
+        )
+      ],
+      doesThrow: false,
+      returnType: Type._UIColor.asOptional(),
+      body: "return UIKit.UIColor(resource: \(qualifiedName), compatibleWith: traitCollection)"
+    )
+  }
+}

--- a/Sources/RswiftCore/Generators/ColorStructGenerator.swift
+++ b/Sources/RswiftCore/Generators/ColorStructGenerator.swift
@@ -47,6 +47,7 @@ struct ColorStructGenerator: ExternalOnlyStructGenerator {
     }
 
     return Struct(
+      availables: ["tvOS 11.0, *", "iOS 11.0, *"],
       comments: ["This `\(qualifiedName)` struct is generated, and contains static references to \(colorLets.count) colors."],
       accessModifier: externalAccessLevel,
       type: Type(module: .host, name: structName),
@@ -118,6 +119,7 @@ private extension NamespacedAssetSubfolder {
     }
 
     return Struct(
+      availables: ["tvOS 11.0, *", "iOS 11.0, *"],
       comments: ["This `\(qualifiedName)` struct is generated, and contains static references to \(colorLets.count) colors."],
       accessModifier: externalAccessLevel,
       type: Type(module: .host, name: structName),

--- a/Sources/RswiftCore/Generators/ColorStructGenerator.swift
+++ b/Sources/RswiftCore/Generators/ColorStructGenerator.swift
@@ -32,6 +32,7 @@ struct ColorStructGenerator: ExternalOnlyStructGenerator {
 
     let structs = assetSubfolders.folders
       .map { $0.generatedColorStruct(at: externalAccessLevel, prefix: qualifiedName) }
+      .filter { !$0.isEmpty }
 
     let colorLets = groupedColors
       .uniques
@@ -104,6 +105,7 @@ private extension NamespacedAssetSubfolder {
     let qualifiedName = prefix + structName
     let structs = assetSubfolders.folders
       .map { $0.generatedColorStruct(at: externalAccessLevel, prefix: qualifiedName) }
+      .filter { !$0.isEmpty }
 
     let colorLets = groupedFunctions
       .uniques
@@ -119,7 +121,7 @@ private extension NamespacedAssetSubfolder {
     }
 
     return Struct(
-      availables: ["tvOS 11.0, *", "iOS 11.0, *"],
+      availables: [],
       comments: ["This `\(qualifiedName)` struct is generated, and contains static references to \(colorLets.count) colors."],
       accessModifier: externalAccessLevel,
       type: Type(module: .host, name: structName),

--- a/Sources/RswiftCore/Generators/FontStructGenerator.swift
+++ b/Sources/RswiftCore/Generators/FontStructGenerator.swift
@@ -75,6 +75,7 @@ struct FontStructGenerator: ExternalOnlyStructGenerator {
     }
 
     return Struct(
+      availables: [],
       comments: ["This `R.font` struct is generated, and contains static references to \(fonts.count) fonts."],
       accessModifier: externalAccessLevel,
       type: Type(module: .host, name: structName),

--- a/Sources/RswiftCore/Generators/ImageStructGenerator.swift
+++ b/Sources/RswiftCore/Generators/ImageStructGenerator.swift
@@ -43,6 +43,7 @@ struct ImageStructGenerator: ExternalOnlyStructGenerator {
 
     let structs = assetSubfolders.folders
       .map { $0.generatedImageStruct(at: externalAccessLevel, prefix: qualifiedName) }
+      .filter { !$0.isEmpty }
 
     let imageLets = groupedFunctions
       .uniques
@@ -115,6 +116,7 @@ private extension NamespacedAssetSubfolder {
     let qualifiedName = prefix + structName
     let structs = assetSubfolders.folders
       .map { $0.generatedImageStruct(at: externalAccessLevel, prefix: qualifiedName) }
+      .filter { !$0.isEmpty }
 
     let imageLets = groupedFunctions
       .uniques

--- a/Sources/RswiftCore/Generators/ImageStructGenerator.swift
+++ b/Sources/RswiftCore/Generators/ImageStructGenerator.swift
@@ -42,7 +42,7 @@ struct ImageStructGenerator: ExternalOnlyStructGenerator {
     assetSubfolders.printWarningsForDuplicates()
 
     let structs = assetSubfolders.folders
-      .map { $0.generatedStruct(at: externalAccessLevel, prefix: qualifiedName) }
+      .map { $0.generatedImageStruct(at: externalAccessLevel, prefix: qualifiedName) }
 
     let imageLets = groupedFunctions
       .uniques
@@ -95,8 +95,8 @@ struct ImageStructGenerator: ExternalOnlyStructGenerator {
   }
 }
 
-extension NamespacedAssetSubfolder: ExternalOnlyStructGenerator {
-  func generatedStruct(at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier) -> Struct {
+private extension NamespacedAssetSubfolder {
+  func generatedImageStruct(at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier) -> Struct {
     let allFunctions = imageAssets
     let groupedFunctions = allFunctions.groupedBySwiftIdentifier { $0 }
 
@@ -113,7 +113,7 @@ extension NamespacedAssetSubfolder: ExternalOnlyStructGenerator {
     let structName = SwiftIdentifier(name: self.name)
     let qualifiedName = prefix + structName
     let structs = assetSubfolders.folders
-      .map { $0.generatedStruct(at: externalAccessLevel, prefix: qualifiedName) }
+      .map { $0.generatedImageStruct(at: externalAccessLevel, prefix: qualifiedName) }
 
     let imageLets = groupedFunctions
       .uniques

--- a/Sources/RswiftCore/Generators/ImageStructGenerator.swift
+++ b/Sources/RswiftCore/Generators/ImageStructGenerator.swift
@@ -58,6 +58,7 @@ struct ImageStructGenerator: ExternalOnlyStructGenerator {
     }
 
     return Struct(
+      availables: [],
       comments: ["This `\(qualifiedName)` struct is generated, and contains static references to \(imageLets.count) images."],
       accessModifier: externalAccessLevel,
       type: Type(module: .host, name: structName),
@@ -129,6 +130,7 @@ private extension NamespacedAssetSubfolder {
     }
 
     return Struct(
+      availables: [],
       comments: ["This `\(qualifiedName)` struct is generated, and contains static references to \(imageLets.count) images."],
       accessModifier: externalAccessLevel,
       type: Type(module: .host, name: structName),

--- a/Sources/RswiftCore/Generators/NibStructGenerator.swift
+++ b/Sources/RswiftCore/Generators/NibStructGenerator.swift
@@ -46,6 +46,7 @@ struct NibStructGenerator: StructGenerator {
     groupedNibs.printWarningsForDuplicatesAndEmpties(source: "xib", result: "file")
 
     let internalStruct = Struct(
+      availables: [],
       comments: [],
       accessModifier: externalAccessLevel,
       type: Type(module: .host, name: structName),
@@ -67,6 +68,7 @@ struct NibStructGenerator: StructGenerator {
       .map { nibFunc(for: $0, at: externalAccessLevel, prefix: qualifiedName) }
 
     let externalStruct = Struct(
+      availables: [],
       comments: ["This `\(qualifiedName)` struct is generated, and contains static references to \(nibProperties.count) nibs."],
       accessModifier: externalAccessLevel,
       type: Type(module: .host, name: structName),
@@ -206,6 +208,7 @@ struct NibStructGenerator: StructGenerator {
     let sanitizedName = SwiftIdentifier(name: nib.name, lowercaseStartingCharacters: false)
 
     return Struct(
+      availables: [],
       comments: [],
       accessModifier: externalAccessLevel,
       type: Type(module: .host, name: SwiftIdentifier(name: "_\(sanitizedName)")),

--- a/Sources/RswiftCore/Generators/ResourceFileStructGenerator.swift
+++ b/Sources/RswiftCore/Generators/ResourceFileStructGenerator.swift
@@ -28,6 +28,7 @@ struct ResourceFileStructGenerator: ExternalOnlyStructGenerator {
     let firstLocales = groupedLocalized.uniques.map { ($0.0, Array($0.1.prefix(1))) }
 
     return Struct(
+      availables: [],
       comments: ["This `\(qualifiedName)` struct is generated, and contains static references to \(firstLocales.count) files."],
       accessModifier: externalAccessLevel,
       type: Type(module: .host, name: structName),

--- a/Sources/RswiftCore/Generators/ReuseIdentifierGenerator.swift
+++ b/Sources/RswiftCore/Generators/ReuseIdentifierGenerator.swift
@@ -32,6 +32,7 @@ struct ReuseIdentifierStructGenerator: ExternalOnlyStructGenerator {
       .map { letFromReusable($0, at: externalAccessLevel) }
 
     return Struct(
+      availables: [],
       comments: ["This `\(qualifiedName)` struct is generated, and contains static references to \(reuseIdentifierProperties.count) reuse identifiers."],
       accessModifier: externalAccessLevel,
       type: Type(module: .host, name: structName),

--- a/Sources/RswiftCore/Generators/SegueGenerator.swift
+++ b/Sources/RswiftCore/Generators/SegueGenerator.swift
@@ -71,6 +71,7 @@ struct SegueStructGenerator: ExternalOnlyStructGenerator {
     }
 
     return Struct(
+      availables: [],
       comments: ["This `\(qualifiedName)` struct is generated, and contains static references to \(structs.count) view controllers."],
       accessModifier: externalAccessLevel,
       type: Type(module: .host, name: structName),
@@ -153,6 +154,7 @@ struct SegueStructGenerator: ExternalOnlyStructGenerator {
     let typeName = SwiftIdentifier(name: sourceType.description)
 
     return Struct(
+      availables: [],
       comments: ["This struct is generated for `\(sourceType.name)`, and contains static references to \(properties.count) segues."],
       accessModifier: externalAccessLevel,
       type: Type(module: .host, name: typeName),

--- a/Sources/RswiftCore/Generators/StoryboardGenerator.swift
+++ b/Sources/RswiftCore/Generators/StoryboardGenerator.swift
@@ -55,6 +55,7 @@ struct StoryboardStructGenerator: StructGenerator {
       }
 
     let externalStruct = Struct(
+      availables: [],
         comments: ["This `\(qualifiedName)` struct is generated, and contains static references to \(storyboardTypes.count) storyboards."],
         accessModifier: externalAccessLevel,
         type: Type(module: .host, name: structName),
@@ -67,6 +68,7 @@ struct StoryboardStructGenerator: StructGenerator {
       )
 
     let internalStruct = Struct(
+      availables: [],
       comments: [],
       accessModifier: externalAccessLevel,
       type: Type(module: .host, name: structName),
@@ -185,6 +187,7 @@ struct StoryboardStructGenerator: StructGenerator {
 
     // Return
     return Struct(
+      availables: [],
       comments: [],
       accessModifier: externalAccessLevel,
       type: Type(module: .host, name: structName),

--- a/Sources/RswiftCore/Generators/StringsStructGenerator.swift
+++ b/Sources/RswiftCore/Generators/StringsStructGenerator.swift
@@ -30,6 +30,7 @@ struct StringsStructGenerator: ExternalOnlyStructGenerator {
     }
 
     return Struct(
+      availables: [],
       comments: ["This `\(qualifiedName)` struct is generated, and contains static references to \(groupedLocalized.uniques.count) localization tables."],
       accessModifier: externalAccessLevel,
       type: Type(module: .host, name: structName),
@@ -50,6 +51,7 @@ struct StringsStructGenerator: ExternalOnlyStructGenerator {
     let params = computeParams(filename: filename, strings: strings)
 
     return Struct(
+      availables: [],
       comments: ["This `\(qualifiedName)` struct is generated, and contains static references to \(params.count) localization keys."],
       accessModifier: externalAccessLevel,
       type: Type(module: .host, name: structName),

--- a/Sources/RswiftCore/Generators/ValidatedStructGenerator.swift
+++ b/Sources/RswiftCore/Generators/ValidatedStructGenerator.swift
@@ -29,6 +29,7 @@ class ValidatedStructGenerator: StructGenerator {
     }
 
     let validationStruct = Struct(
+      availables: [],
       comments: [],
       accessModifier: .filePrivate,
       type: Type(module: .host, name: "intern"),

--- a/Sources/RswiftCore/ResourceTypes/Font.swift
+++ b/Sources/RswiftCore/ResourceTypes/Font.swift
@@ -23,9 +23,10 @@ struct Font: WhiteListedExtensionsResourceType {
     guard let dataProvider = CGDataProvider(url: url as CFURL) else {
       throw ResourceParsingError.parsingFailed("Unable to create data provider for font at \(url)")
     }
-    let font = CGFont(dataProvider)
 
-    guard let postScriptName = font.postScriptName else {
+    let font: CGFont? = CGFont(dataProvider)
+
+    guard let postScriptName = font?.postScriptName else {
       throw ResourceParsingError.parsingFailed("No postscriptName associated to font at \(url)")
     }
 

--- a/Sources/RswiftCore/RswiftCore.swift
+++ b/Sources/RswiftCore/RswiftCore.swift
@@ -28,9 +28,8 @@ public struct RswiftCore {
 
       let resources = Resources(resourceURLs: resourceURLs, fileManager: FileManager.default)
 
-      let generators: [StructGenerator] = [
+      var generators: [StructGenerator] = [
         ImageStructGenerator(assetFolders: resources.assetFolders, images: resources.images),
-        ColorStructGenerator(colorPalettes: resources.colors),
         FontStructGenerator(fonts: resources.fonts),
         SegueStructGenerator(storyboards: resources.storyboards),
         StoryboardStructGenerator(storyboards: resources.storyboards),
@@ -39,6 +38,14 @@ public struct RswiftCore {
         ResourceFileStructGenerator(resourceFiles: resources.resourceFiles),
         StringsStructGenerator(localizableStrings: resources.localizableStrings),
       ]
+
+      do {
+        let colorPaletteGenerator = ColorPaletteStructGenerator(palettes: resources.colors)
+        let colorPaletteGeneratorStruct = colorPaletteGenerator.generatedStructs(at: callInformation.accessLevel, prefix: "")
+        if colorPaletteGeneratorStruct.externalStruct.structs.count > 0 {
+          generators.append(colorPaletteGenerator)
+        }
+      }
 
       let aggregatedResult = AggregatedStructGenerator(subgenerators: generators)
         .generatedStructs(at: callInformation.accessLevel, prefix: "")

--- a/Sources/RswiftCore/RswiftCore.swift
+++ b/Sources/RswiftCore/RswiftCore.swift
@@ -30,6 +30,7 @@ public struct RswiftCore {
 
       var generators: [StructGenerator] = [
         ImageStructGenerator(assetFolders: resources.assetFolders, images: resources.images),
+        ColorStructGenerator(assetFolders: resources.assetFolders),
         FontStructGenerator(fonts: resources.fonts),
         SegueStructGenerator(storyboards: resources.storyboards),
         StoryboardStructGenerator(storyboards: resources.storyboards),

--- a/Sources/RswiftCore/RswiftCore.swift
+++ b/Sources/RswiftCore/RswiftCore.swift
@@ -43,7 +43,7 @@ public struct RswiftCore {
       do {
         let colorPaletteGenerator = ColorPaletteStructGenerator(palettes: resources.colors)
         let colorPaletteGeneratorStruct = colorPaletteGenerator.generatedStructs(at: callInformation.accessLevel, prefix: "")
-        if colorPaletteGeneratorStruct.externalStruct.structs.count > 0 {
+        if !colorPaletteGeneratorStruct.externalStruct.isEmpty {
           generators.append(colorPaletteGenerator)
         }
       }

--- a/Sources/RswiftCore/SwiftTypes/Struct.swift
+++ b/Sources/RswiftCore/SwiftTypes/Struct.swift
@@ -10,6 +10,7 @@
 import Foundation
 
 struct Struct: UsedTypesProvider, SwiftCodeConverible {
+  let availables: [String]
   let comments: [String]
   let accessModifier: AccessLevel
   let type: Type
@@ -33,6 +34,7 @@ struct Struct: UsedTypesProvider, SwiftCodeConverible {
 
   var swiftCode: String {
     let commentsString = comments.map { "/// \($0)\n" }.joined(separator: "")
+    let availablesString = availables.map { "@available(\($0))\n" }.joined(separator: "")
     let accessModifierString = accessModifier.swiftCode
     let implementsString = implements.count > 0 ? ": " + implements.map { $0.swiftCode }.joined(separator: ", ") : ""
 
@@ -71,6 +73,6 @@ struct Struct: UsedTypesProvider, SwiftCodeConverible {
     let bodyComponents = [typealiasString, varsString, functionsString, structsString, classesString, fileprivateInit].filter { $0 != "" }
     let bodyString = bodyComponents.joined(separator: "\n\n").indent(with: "  ")
 
-    return "\(commentsString)\(accessModifierString)struct \(type)\(implementsString) {\n\(bodyString)\n}"
+    return "\(commentsString)\(availablesString)\(accessModifierString)struct \(type)\(implementsString) {\n\(bodyString)\n}"
   }
 }

--- a/Sources/RswiftCore/SwiftTypes/Struct.swift
+++ b/Sources/RswiftCore/SwiftTypes/Struct.swift
@@ -21,6 +21,13 @@ struct Struct: UsedTypesProvider, SwiftCodeConverible {
   var structs: [Struct]
   var classes: [Class]
 
+  var isEmpty: Bool {
+    return properties.isEmpty
+      && functions.isEmpty
+      && (structs.isEmpty || structs.all { $0.isEmpty })
+      && classes.isEmpty
+  }
+
   var usedTypes: [UsedType] {
     return [
         type.usedTypes,

--- a/Sources/RswiftCore/SwiftTypes/Type.swift
+++ b/Sources/RswiftCore/SwiftTypes/Type.swift
@@ -54,6 +54,7 @@ struct Type: UsedTypesProvider, CustomStringConvertible, Hashable {
   static let NibResourceType = Type(module: "Rswift", name: "NibResourceType")
   static let FileResource = Type(module: "Rswift", name: "FileResource")
   static let FontResource = Type(module: "Rswift", name: "FontResource")
+  static let ColorPaletteItemResource = Type(module: "Rswift", name: "ColorPaletteItemResource")
   static let ColorResource = Type(module: "Rswift", name: "ColorResource")
   static let ImageResource = Type(module: "Rswift", name: "ImageResource")
   static let StringResource = Type(module: "Rswift", name: "StringResource")

--- a/Sources/RswiftCore/Util/UtilExtensions.swift
+++ b/Sources/RswiftCore/Util/UtilExtensions.swift
@@ -32,6 +32,10 @@ extension Sequence {
 
     return groupedBy
   }
+
+  func all(where predicate: (Self.Element) throws -> Bool) rethrows -> Bool {
+    return !(try contains(where: { !(try predicate($0)) }))
+  }
 }
 
 extension Sequence where Iterator.Element : Sequence {


### PR DESCRIPTION
⚠️ **Breaking change!**

Renames previous `R.color.*` for .clr resources to `R.clr.*`, marked as deprecated.

Introduces new `R.color.*`, build on Xcode 9 color assets.

Requires https://github.com/mac-cain13/R.swift.Library/pull/22


- [ ] Reuse duplicate code for Image assets and Color assets?