### PR TITLE
Attempt to not include empty structs into the generated file.

### DIFF
--- a/Sources/RswiftCore/Generators/AggregatedStructGenerator.swift
+++ b/Sources/RswiftCore/Generators/AggregatedStructGenerator.swift
@@ -23,12 +23,12 @@ class AggregatedStructGenerator: StructGenerator {
 
     let collectedResult = subgenerators
       .flatMap {
-		  let result = $0.generatedStructs(at: externalAccessLevel, prefix: qualifiedName)
-		  if result.externalStruct.isEmpty { return nil }
-		  if let internalStruct = result.internalStruct, internalStruct.isEmpty { return nil }
+        let result = $0.generatedStructs(at: externalAccessLevel, prefix: qualifiedName)
+        if result.externalStruct.isEmpty { return nil }
+        if let internalStruct = result.internalStruct, internalStruct.isEmpty { return nil }
 
-		  return result
-		}
+        return result
+      }
       .reduce(StructGeneratorResultCollector()) { collector, result in collector.appending(result) }
 
     let externalStruct = Struct(

--- a/Sources/RswiftCore/Generators/AggregatedStructGenerator.swift
+++ b/Sources/RswiftCore/Generators/AggregatedStructGenerator.swift
@@ -22,7 +22,13 @@ class AggregatedStructGenerator: StructGenerator {
     let internalStructName: SwiftIdentifier = "_R"
 
     let collectedResult = subgenerators
-      .map { $0.generatedStructs(at: externalAccessLevel, prefix: qualifiedName) }
+      .flatMap {
+		  let result = $0.generatedStructs(at: externalAccessLevel, prefix: qualifiedName)
+		  if result.externalStruct.isEmpty { return nil }
+		  if let internalStruct = result.internalStruct, internalStruct.isEmpty { return nil }
+
+		  return result
+		}
       .reduce(StructGeneratorResultCollector()) { collector, result in collector.appending(result) }
 
     let externalStruct = Struct(


### PR DESCRIPTION
HI! I am trying to alter the generation of the structs so that the generated R file wouldn't include the empty ones. Strangely enough, when I reference this commit in the `Podfile`, so that I would have this version instead of the `4.0.0` tag, after `pod install` I am not able to build anymore. The original project after my changes compiles just fine, it is only through Cocoapods - `rswift` file is simply not there.
Could you help me out please? Maybe I have missed something. Really struggling here. Thanks!