### PR TITLE
Docs - QA - improve: use in library

### DIFF
--- a/Documentation/QandA.md
+++ b/Documentation/QandA.md
@@ -35,9 +35,9 @@ Work around this problem by [*emptying* the module field in the xib or storyboar
 
 ## Can I use R.swift in a library?
 
-Yes, just add R.swift as a buildstep in your library project and it will work just like normal. If you want to expose the resources to users of your library you have to make the generated code public, you can do this by adding `--accessLevel public` to the call to R.swift.
+Yes, just add R.swift as a buildstep in your library project and it will work just like normal. This works best if you have a dedicated Xcode project you can use to add the build script to. For Cocoapod users: this is [not the case](https://github.com/mac-cain13/R.swift/issues/430#issue-344112657) if you've used `pod lib create MyNewLib` to scaffold your library.
 
-For example Cocoapods users would change their build step to: `"$SRCROOT/rswift" generate --accessLevel public "$SRCROOT"`
+If you want to expose the resources to users of your library you have to make the generated code public, you can do this by adding `--accessLevel public` to the call to R.swift. For example, if you included R.swift as a cocoapod dependency to your library project, you would change your build step to: `"$PODS_ROOT/R.swift/rswift" generate --accessLevel public "$SRCROOT"`
 
 ## How does R.swift work?
 


### PR DESCRIPTION
- State you ideally need a dedicated xcode project to include build script

- Add link to issue explaining this

- Change example script with `accessLevel` for Cocoapod users: 
If you have a dedicated xcode project for your library and you use R.swift in your library you need to install it somehow right? Probably with a regular Podfile? and thus the script needs to be changed to `"$SRCROOT/Pods/R.swift/rswift" generate "$SRCROOT"`