### PR TITLE
Performance Tweaks

### DIFF
--- a/Sources/RswiftCore/ResourceTypes/Resources.swift
+++ b/Sources/RswiftCore/ResourceTypes/Resources.swift
@@ -26,15 +26,43 @@ struct Resources {
   let reusables: [Reusable]
 
   init(resourceURLs: [URL], fileManager: FileManager) {
-    assetFolders = resourceURLs.compactMap { url in tryResourceParsing { try AssetFolder(url: url, fileManager: fileManager) } }
-    images = resourceURLs.compactMap { url in tryResourceParsing { try Image(url: url) } }
-    fonts = resourceURLs.compactMap { url in tryResourceParsing { try Font(url: url) } }
-    nibs = resourceURLs.compactMap { url in tryResourceParsing { try Nib(url: url) } }
-    storyboards = resourceURLs.compactMap { url in tryResourceParsing { try Storyboard(url: url) } }
-    resourceFiles = resourceURLs.compactMap { url in tryResourceParsing { try ResourceFile(url: url) } }
+    
+    var assetFolders = [AssetFolder]()
+    var images = [Image]()
+    var fonts = [Font]()
+    var nibs = [Nib]()
+    var storyboards = [Storyboard]()
+    var resourceFiles = [ResourceFile]()
+    var localizableStrings = [LocalizableStrings]()
+    
+    resourceURLs.forEach { url in
+      if let nib = tryResourceParsing({ try Nib(url: url) }) {
+        nibs.append(nib)
+      } else if let image = tryResourceParsing({ try Image(url: url) }) {
+        images.append(image)
+      } else if let asset = tryResourceParsing({ try AssetFolder(url: url, fileManager: fileManager) }) {
+        assetFolders.append(asset)
+      } else if let font = tryResourceParsing({ try Font(url: url) }) {
+        fonts.append(font)
+      } else if let storyboard = tryResourceParsing({ try Storyboard(url: url) }) {
+        storyboards.append(storyboard)
+      } else if let resourceFile = tryResourceParsing({ try ResourceFile(url: url) }) {
+        resourceFiles.append(resourceFile)
+      } else if let localizableString = tryResourceParsing({ try LocalizableStrings(url: url) }) {
+        localizableStrings.append(localizableString)
+      }
+    }
+    
+    self.assetFolders = assetFolders
+    self.images = images
+    self.fonts = fonts
+    self.nibs = nibs
+    self.storyboards = storyboards
+    self.resourceFiles = resourceFiles
+    self.localizableStrings = localizableStrings
+    
     reusables = (nibs.map { $0 as ReusableContainer } + storyboards.map { $0 as ReusableContainer })
       .flatMap { $0.reusables }
-    localizableStrings = resourceURLs.compactMap { url in tryResourceParsing { try LocalizableStrings(url: url) } }
   }
 }
 

--- a/Sources/RswiftCore/Util/Glob.swift
+++ b/Sources/RswiftCore/Util/Glob.swift
@@ -188,16 +188,15 @@ public class Glob: Collection {
   }
 
   private func isDirectory(path: String) -> Bool {
-    var isDirectory = isDirectoryCache[path]
-    if let isDirectory = isDirectory {
+    if let isDirectory = isDirectoryCache[path] {
       return isDirectory
     }
 
     var isDirectoryBool = ObjCBool(false)
-    isDirectory = FileManager.default.fileExists(atPath: path, isDirectory: &isDirectoryBool) && isDirectoryBool.boolValue
-    isDirectoryCache[path] = isDirectory!
+    let isDirectory = FileManager.default.fileExists(atPath: path, isDirectory: &isDirectoryBool) && isDirectoryBool.boolValue
+    isDirectoryCache[path] = isDirectory
 
-    return isDirectory!
+    return isDirectory
   }
 
   private func clearCaches() {

--- a/Sources/RswiftCore/Util/Glob.swift
+++ b/Sources/RswiftCore/Util/Glob.swift
@@ -60,7 +60,6 @@ public class Glob: Collection {
 
   public static let defaultBlacklistedDirectories = ["node_modules", "Pods"]
 
-
   private var isDirectoryCache = [String: Bool]()
 
   public let behavior: Behavior

--- a/Sources/RswiftCore/Util/Glob.swift
+++ b/Sources/RswiftCore/Util/Glob.swift
@@ -132,17 +132,28 @@ public class Glob: Collection {
     let fileManager = FileManager.default
 
     var directories: [String]
+    
+    let blacklist = [
+      "node_modules",
+      "Pods"
+    ]
 
     do {
-      directories = try fileManager.subpathsOfDirectory(atPath: firstPart).compactMap { subpath in
-        let fullPath = NSString(string: firstPart).appendingPathComponent(subpath)
-        var isDirectory = ObjCBool(false)
-        if fileManager.fileExists(atPath: fullPath, isDirectory: &isDirectory) && isDirectory.boolValue {
-          return fullPath
-        } else {
+      directories = try fileManager.contentsOfDirectory(atPath: firstPart).compactMap { subpath -> [String]? in
+        if blacklist.contains(subpath) {
           return nil
         }
-      }
+        let secondPart = NSString(string: firstPart).appendingPathComponent(subpath)
+        return try fileManager.subpathsOfDirectory(atPath: secondPart).compactMap { subpath in
+          let fullPath = NSString(string: secondPart).appendingPathComponent(subpath)
+          var isDirectory = ObjCBool(false)
+          if fileManager.fileExists(atPath: fullPath, isDirectory: &isDirectory) && isDirectory.boolValue {
+            return fullPath
+          } else {
+            return nil
+          }
+        }
+      }.joined().array()
     } catch {
       directories = []
       print("Error parsing file system item: \(error)")

--- a/Tests/RswiftCoreTests/GlobTests.swift
+++ b/Tests/RswiftCoreTests/GlobTests.swift
@@ -266,21 +266,14 @@ class GlobTests : XCTestCase {
   }
 
   func testBlacklistedDirectories() {
-    // Should be the equivalent of
-    // FileTree tree = project.fileTree((Object)'/tmp') {
-    //   include 'glob-test.7m0Lp/**/dir2/**/*'
-    // }
-    //
-    // Note that the sort order currently matches Bash and not Gradle
     let pattern = "\(tmpDir)/**/*"
 
-    let glob = Glob(pattern: pattern, behavior: GlobBehaviorGradle, blacklistedDirectories: ["baz", "foo"])
+    let glob = Glob(pattern: pattern, behavior: GlobBehaviorGradle, blacklistedDirectories: ["dir1"])
 
     XCTAssertEqual(glob.paths, [
       "\(tmpDir)/bar",
-      "\(tmpDir)/dir1/dir2/dir3/file2.ext",
-      "\(tmpDir)/dir1/file1.ext",
-      "\(tmpDir)/dir1/file1.extfoo",
+      "\(tmpDir)/baz",
+      "\(tmpDir)/foo",
       ])
   }
 }


### PR DESCRIPTION
# What

This PR brings 2 performance enhancements.

## Ignored Files

When ignoring files using `.rswiftignore`, all potential ignored files are calculated during the creation of `IgnoreFile`. It iterates recursively through all subdirectories in `.rswiftignore`'s root directory. The problem here is that will often include `Pods`, and depending on the project could include `node_modules` as well. These directories can of course be massively complex compared to the actual user project.

Instead of iterating recursively through all subdirectories from root, the new solution is to do a shallow iteration through the root directory, ignore `Pods` and `node_modules`, and then iterate recursively through the rest.

## Identifying Resources

Large projects can have a significant amount of resources. In `Resources.init`, all the resources were being iterated over 6 times. Iterating over them once brings a marginal speedup.

# Benchmarks

## Ignored Files

### Before
<img width="967" alt="screen shot 2018-09-23 at 1 18 59 pm" src="https://user-images.githubusercontent.com/538433/45931422-aa86d300-bf33-11e8-98f9-385d8df5ee19.png">

### After
<img width="941" alt="screen shot 2018-09-23 at 1 21 05 pm" src="https://user-images.githubusercontent.com/538433/45931427-b4a8d180-bf33-11e8-8e20-5280811339a8.png">

## Identifying Resources

### Before
<img width="906" alt="screen shot 2018-09-23 at 1 19 22 pm" src="https://user-images.githubusercontent.com/538433/45931432-c12d2a00-bf33-11e8-8815-e912664443d2.png">

### After
<img width="878" alt="screen shot 2018-09-23 at 1 20 26 pm" src="https://user-images.githubusercontent.com/538433/45931435-c4281a80-bf33-11e8-8a37-e96da3c23e30.png">

These benchmarks are using the project I spend the majority of my time in, which is rather large. However, the speed ups should apply universally to all projects. Though projects using a `.rswiftignore` file that aren't using Cocoapods probably won't get much benefit.