### PR TITLE
Sort results so output is consistent every run.

### DIFF
--- a/ResourceApp.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/ResourceApp.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/ResourceApp/ResourceApp.xcodeproj/project.pbxproj
+++ b/ResourceApp/ResourceApp.xcodeproj/project.pbxproj
@@ -187,7 +187,7 @@
 		DEF559AB1CA48892009B8C51 /* ResourceAppTests-tvOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "ResourceAppTests-tvOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		DEF559AD1CA48892009B8C51 /* ResourceAppTests_tvOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResourceAppTests_tvOS.swift; sourceTree = "<group>"; };
 		DEF559AF1CA48892009B8C51 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		DEF559B61CA48DC2009B8C51 /* R.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = R.generated.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		DEF559B61CA48DC2009B8C51 /* R.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = R.generated.swift; sourceTree = "<group>"; };
 		E1B2B4287A3B52DAB3098AA2 /* Pods_Shared_ResourceAppTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Shared_ResourceAppTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E20983231D585E78005ACBAA /* SegueTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SegueTests.swift; sourceTree = "<group>"; };
 		E20983251D585F8C005ACBAA /* Xib with ViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = "Xib with ViewController.xib"; sourceTree = "<group>"; };
@@ -812,7 +812,6 @@
 			);
 			name = R.swift;
 			outputPaths = (
-				"$(SRCROOT)/R.generated.swift",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/ResourceApp/ResourceAppTests/ResourceAppTests.swift
+++ b/ResourceApp/ResourceAppTests/ResourceAppTests.swift
@@ -45,8 +45,7 @@ class ResourceAppTests: XCTestCase {
     warning: [R.swift] Skipping 1 string in 'Generic' because no swift identifier can be generated for key: '#'
     """
     .trimmingCharacters(in: .whitespacesAndNewlines)
-    .components(separatedBy: "\n") + "warning: [R.swift] project.pbxproj is internally inconsistent.\n\n - PBXBuildFile (DEADBEEFDEADBEEFDEADBEEF) references missing fileRef C0FEFEC0FEFEC0FEFEC0FEFE\n - PBXBuildFile (DEADBEEFDEADBEEFDEADBEEF) is not used\n\nPerhaps a merge conflict?\n"
-      .components(separatedBy: "\n")
+    .components(separatedBy: "\n")
 
   func testWarningsAreLogged() {
     guard let logURL = Bundle(for: ResourceAppTests.self).url(forResource: "rswift", withExtension: "log") else {

--- a/Sources/RswiftCore/Generators/NibStructGenerator.swift
+++ b/Sources/RswiftCore/Generators/NibStructGenerator.swift
@@ -198,11 +198,11 @@ struct NibStructGenerator: StructGenerator {
     }
 
     // Validation
-    let validateImagesLines = Set(nib.usedImageIdentifiers)
+    let validateImagesLines = nib.usedImageIdentifiers.uniqueAndSorted()
       .map {
         "if UIKit.UIImage(named: \"\($0)\", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: \"[R.swift] Image named '\($0)' is used in nib '\(nib.name)', but couldn't be loaded.\") }"
       }
-    let validateColorLines = Set(nib.usedColorResources)
+    let validateColorLines = nib.usedColorResources.uniqueAndSorted()
       .map {
         "if UIKit.UIColor(named: \"\($0)\") == nil { throw Rswift.ValidationError(description: \"[R.swift] Color named '\($0)' is used in storyboard '\(nib.name)', but couldn't be loaded.\") }"
       }

--- a/Sources/RswiftCore/Generators/StoryboardGenerator.swift
+++ b/Sources/RswiftCore/Generators/StoryboardGenerator.swift
@@ -158,11 +158,11 @@ struct StoryboardStructGenerator: StructGenerator {
       .forEach { functions.append($0) }
 
     // Validation
-    let validateImagesLines = Set(storyboard.usedImageIdentifiers)
+    let validateImagesLines = storyboard.usedImageIdentifiers.uniqueAndSorted()
       .map {
         "if UIKit.UIImage(named: \"\($0)\") == nil { throw Rswift.ValidationError(description: \"[R.swift] Image named '\($0)' is used in storyboard '\(storyboard.name)', but couldn't be loaded.\") }"
       }
-    let validateColorLines = Set(storyboard.usedColorResources)
+    let validateColorLines = storyboard.usedColorResources.uniqueAndSorted()
       .map {
         "if UIKit.UIColor(named: \"\($0)\") == nil { throw Rswift.ValidationError(description: \"[R.swift] Color named '\($0)' is used in storyboard '\(storyboard.name)', but couldn't be loaded.\") }"
       }

--- a/Sources/RswiftCore/Util/SwiftIdentifier.swift
+++ b/Sources/RswiftCore/Util/SwiftIdentifier.swift
@@ -126,9 +126,11 @@ extension Sequence {
     groupedBy[empty] = nil
 
     let uniques = Array(groupedBy.values.filter { $0.count == 1 }.joined())
+        .sorted { identifierSelector($0) < identifierSelector($1) }
     let duplicates = groupedBy
       .filter { $0.1.count > 1 }
       .map { ($0.0, $0.1.map(identifierSelector).sorted()) }
+        .sorted { $0.0.description < $1.0.description }
 
     return SwiftNameGroups(uniques: uniques, duplicates: duplicates, empties: empties ?? [])
   }

--- a/Sources/RswiftCore/Util/SwiftIdentifier.swift
+++ b/Sources/RswiftCore/Util/SwiftIdentifier.swift
@@ -126,11 +126,11 @@ extension Sequence {
     groupedBy[empty] = nil
 
     let uniques = Array(groupedBy.values.filter { $0.count == 1 }.joined())
-        .sorted { identifierSelector($0) < identifierSelector($1) }
+      .sorted { identifierSelector($0) < identifierSelector($1) }
     let duplicates = groupedBy
       .filter { $0.1.count > 1 }
       .map { ($0.0, $0.1.map(identifierSelector).sorted()) }
-        .sorted { $0.0.description < $1.0.description }
+      .sorted { $0.0.description < $1.0.description }
 
     return SwiftNameGroups(uniques: uniques, duplicates: duplicates, empties: empties ?? [])
   }
@@ -159,7 +159,7 @@ private let blacklistedCharacters: CharacterSet = {
   return blacklist as CharacterSet
 }()
 
-// Based on https://developer.apple.com/library/ios/documentation/Swift/Conceptual/Swift_Programming_Language/LexicalStructure.html#//apple_ref/doc/uid/TP40014097-CH30-ID413
+// Based on https://docs.swift.org/swift-book/ReferenceManual/LexicalStructure.html#ID413
 private let SwiftKeywords = [
   // Keywords used in declarations
   "associatedtype", "class", "deinit", "enum", "extension", "fileprivate", "func", "import", "init", "inout", "internal", "let", "open", "operator", "private", "protocol", "public", "static", "struct", "subscript", "typealias", "var",
@@ -171,7 +171,7 @@ private let SwiftKeywords = [
   "as", "Any", "catch", "false", "is", "nil", "rethrows", "super", "self", "Self", "throw", "throws", "true", "try",
 
   // Keywords that begin with a number sign (#)
-  "#available", "#colorLiteral", "#column", "#else", "#elseif", "#endif", "#file", "#fileLiteral", "#function", "#if", "#imageLiteral", "#line", "#selector", "#sourceLocation",
+  "#available", "#colorLiteral", "#column", "#else", "#elseif", "#endif", "#error", "#file", "#fileLiteral", "#function", "#if", "#imageLiteral", "#line", "#selector", "#sourceLocation", "#warning",
 
   // Keywords from Swift 2 that are still reserved
   "__COLUMN__", "__FILE__", "__FUNCTION__", "__LINE__",

--- a/Sources/RswiftCore/Util/UtilExtensions.swift
+++ b/Sources/RswiftCore/Util/UtilExtensions.swift
@@ -17,6 +17,12 @@ extension Array {
   }
 }
 
+extension Array where Element: Comparable, Element: Hashable {
+  func uniqueAndSorted() -> [Element] {
+    return Set<Element>(self).array().sorted()
+  }
+}
+
 // MARK: Sequence operations
 
 extension Sequence {


### PR DESCRIPTION
# What

I noticed on the latest alpha, `R.generated.swift` was slightly different every time. As part of my build, I actually run a local diff on the newly generated `R.generated.swift` and the existing one, and only use the new one if something has changed. Otherwise, Xcode would always see that a file had been touched, and the incremental builds would not be as efficient as they could be.

This PR just sorts things that were mapped to a non-ordered data type at some point.

I might have missed some, but this was at least giving my project consistent results. 