### PR TITLE
#402 Append command option for hierarchical strings generation

### DIFF
--- a/ResourceApp/ResourceApp/Strings/en.lproj/Localizable.strings
+++ b/ResourceApp/ResourceApp/Strings/en.lproj/Localizable.strings
@@ -11,3 +11,7 @@ one = One;
 two = 2;
 
 "quote" = "There are %d lights!";
+
+"myComponent.errors.catLoad" = "Unable to load component data";
+"myComponent.errors.unknown" = "Unknown error";
+"myComponent.title" = "Title";

--- a/ResourceApp/ResourceApp/Strings/es.lproj/Localizable.strings
+++ b/ResourceApp/ResourceApp/Strings/es.lproj/Localizable.strings
@@ -11,3 +11,8 @@ one = Uno;
 two = 2;
 
 "quote" = "Hay %d luces!";
+
+//Hierarchycal structs testing
+"myComponent.errors.catLoad" = "No se pueden cargar datos de componentes";
+"myComponent.errors.unknown" = "Error desconocido";
+"myComponent.title" = "Título";

--- a/Sources/RswiftCore/CallInformation.swift
+++ b/Sources/RswiftCore/CallInformation.swift
@@ -28,6 +28,8 @@ public struct CallInformation {
   private let sdkRootURL: URL
   private let platformURL: URL
 
+  let parsingInformation: ParsingInformation
+  
   public init(
     outputURL: URL,
     rswiftIgnoreURL: URL,
@@ -44,7 +46,8 @@ public struct CallInformation {
     developerDirURL: URL,
     sourceRootURL: URL,
     sdkRootURL: URL,
-    platformURL: URL
+    platformURL: URL,
+    parsingInformation: ParsingInformation
   ) {
     self.outputURL = outputURL
     self.rswiftIgnoreURL = rswiftIgnoreURL
@@ -62,6 +65,7 @@ public struct CallInformation {
     self.sourceRootURL = sourceRootURL
     self.sdkRootURL = sdkRootURL
     self.platformURL = platformURL
+    self.parsingInformation = parsingInformation
   }
 
 

--- a/Sources/RswiftCore/Generators/StringsStructGenerator.swift
+++ b/Sources/RswiftCore/Generators/StringsStructGenerator.swift
@@ -341,9 +341,31 @@ private struct LocalizableStringsNode {
   let name: String
   var childs = [String: LocalizableStringsNode]()
   let filename: String
+  var values = [Locale: [String: (params: [StringParam], commentValue: String)]]()
   
   init(_ name: String, filename: String) {
     self.name = name
     self.filename = filename
+  }
+  
+  mutating func addChild(withName childName: String, locale: Locale, filename: String, key: String, value: (params: [StringParam], commentValue: String)) {
+    let splittedName = childName.components(separatedBy: LocalizableStringsNode.nameSeparator)
+    guard filename == self.filename else {
+      return //Incorrect call
+    }
+    guard splittedName.count > 1 else {
+      if values[locale] == nil {
+        values[locale] = [key: value]
+      } else {
+        values[locale]?[key] = value
+      }
+      return
+    }
+    let currentChildName = splittedName.first!
+    let nextChildName = splittedName.dropFirst().joined(separator: LocalizableStringsNode.nameSeparator)
+    if childs[currentChildName] == nil {
+      childs[currentChildName] = LocalizableStringsNode(currentChildName, filename: filename)
+    }
+    childs[currentChildName]?.addChild(withName: nextChildName, locale: locale, filename: filename, key: key, value: value)
   }
 }

--- a/Sources/RswiftCore/Generators/StringsStructGenerator.swift
+++ b/Sources/RswiftCore/Generators/StringsStructGenerator.swift
@@ -12,8 +12,12 @@ import Foundation
 struct StringsStructGenerator: ExternalOnlyStructGenerator {
   private let localizableStrings: [LocalizableStrings]
 
-  init(localizableStrings: [LocalizableStrings]) {
+  //Stored in ParsingInformation.useStringsHierarchy
+  private let useStringsHierarchy: Bool
+  
+  init(localizableStrings: [LocalizableStrings], useStringsHierarchy: Bool = false ) {
     self.localizableStrings = localizableStrings
+    self.useStringsHierarchy = useStringsHierarchy
   }
 
   func generatedStruct(at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier) -> Struct {

--- a/Sources/RswiftCore/Generators/StringsStructGenerator.swift
+++ b/Sources/RswiftCore/Generators/StringsStructGenerator.swift
@@ -335,3 +335,15 @@ private struct StringValues {
     return results
   }
 }
+
+private struct LocalizableStringsNode {
+  static var nameSeparator: String = "."
+  let name: String
+  var childs = [String: LocalizableStringsNode]()
+  let filename: String
+  
+  init(_ name: String, filename: String) {
+    self.name = name
+    self.filename = filename
+  }
+}

--- a/Sources/RswiftCore/Generators/StringsStructGenerator.swift
+++ b/Sources/RswiftCore/Generators/StringsStructGenerator.swift
@@ -27,10 +27,16 @@ struct StringsStructGenerator: ExternalOnlyStructGenerator {
     let groupedLocalized = localized.grouped(bySwiftIdentifier: { $0.0 })
 
     groupedLocalized.printWarningsForDuplicatesAndEmpties(source: "strings file", result: "file")
-
-    let structs = groupedLocalized.uniques.compactMap { arg -> Struct? in
-      let (key, value) = arg
-      return stringStructFromLocalizableStrings(filename: key, strings: value, at: externalAccessLevel, prefix: qualifiedName)
+    
+    let structs: [Struct]
+    switch useStringsHierarchy {
+    case true:
+      structs = []
+    case false:
+      structs = groupedLocalized.uniques.compactMap { arg -> Struct? in
+        let (key, value) = arg
+        return stringStructFromLocalizableStrings(filename: key, strings: value, at: externalAccessLevel, prefix: qualifiedName)
+      }
     }
 
     return Struct(

--- a/Sources/RswiftCore/ParsingInformation.swift
+++ b/Sources/RswiftCore/ParsingInformation.swift
@@ -1,0 +1,18 @@
+//
+//  ParsingInformation.swift
+//  R.swift
+//
+//  Created by Andrey Tchernov on 04.12.2018.
+//  From: https://github.com/icerockdevelop/R.swift
+//  License: MIT License
+//
+
+import Foundation
+
+public struct ParsingInformation {
+  let useStringsHierarchy: Bool
+  public init (useStringsHierarchy: Bool) {
+    self.useStringsHierarchy = useStringsHierarchy
+  }
+  //TODO: Prepare for Json/Plist initialization
+}

--- a/Sources/RswiftCore/RswiftCore.swift
+++ b/Sources/RswiftCore/RswiftCore.swift
@@ -23,7 +23,8 @@ public struct RswiftCore {
         .filter { !ignoreFile.matches(url: $0) }
 
       let resources = Resources(resourceURLs: resourceURLs, fileManager: FileManager.default)
-
+      let parsingInfo = callInformation.parsingInformation
+      
       let generators: [StructGenerator] = [
         ImageStructGenerator(assetFolders: resources.assetFolders, images: resources.images),
         ColorStructGenerator(assetFolders: resources.assetFolders),
@@ -33,7 +34,7 @@ public struct RswiftCore {
         NibStructGenerator(nibs: resources.nibs),
         ReuseIdentifierStructGenerator(reusables: resources.reusables),
         ResourceFileStructGenerator(resourceFiles: resources.resourceFiles),
-        StringsStructGenerator(localizableStrings: resources.localizableStrings),
+        StringsStructGenerator(localizableStrings: resources.localizableStrings, useStringsHierarchy: parsingInfo.useStringsHierarchy),
       ]
 
       let aggregatedResult = AggregatedStructGenerator(subgenerators: generators)

--- a/Sources/rswift/main.swift
+++ b/Sources/rswift/main.swift
@@ -77,6 +77,7 @@ struct CommanderOptions {
 // Options grouped in struct for readability
 struct CommanderArguments {
   static let outputDir = Argument<String>("outputDir", description: "Output directory for the 'R.generated.swift' file.")
+  static let useStringsHierachy = Flag.init("useStringsHierachy")
 }
 
 let generate = command(
@@ -95,8 +96,9 @@ let generate = command(
   CommanderOptions.sourceRoot,
   CommanderOptions.sdkRoot,
 
-  CommanderArguments.outputDir
-) { importModules, accessLevel, rswiftIgnore, xcodeproj, target, bundle, productModule, buildProductsDir, developerDir, sourceRoot, sdkRoot, outputDir in
+  CommanderArguments.outputDir,
+  CommanderArguments.useStringsHierachy
+) { importModules, accessLevel, rswiftIgnore, xcodeproj, target, bundle, productModule, buildProductsDir, developerDir, sourceRoot, sdkRoot, outputDir, useStringsHierachy in
 
   let info = ProcessInfo()
 
@@ -111,7 +113,6 @@ let generate = command(
   let sdkRootPath = try info.value(from: sdkRoot, name: "sdkRoot", key: EnvironmentKeys.sdkRoot)
   let platformPath = try info.value(from: sdkRoot, name: "platformDir", key: EnvironmentKeys.platformDir)
 
-
   let outputURL = URL(fileURLWithPath: outputDir).appendingPathComponent(Rswift.resourceFileName, isDirectory: false)
   let rswiftIgnoreURL = URL(fileURLWithPath: sourceRootPath).appendingPathComponent(rswiftIgnore, isDirectory: false)
   let modules = importModules
@@ -120,6 +121,8 @@ let generate = command(
     .filter { !$0.isEmpty }
     .map { Module.custom(name: $0) }
 
+  //TODO: Support Json/Plist for other options, cause commander support 14 total parameters in call
+  let parsingInfo = ParsingInformation(useStringsHierarchy: useStringsHierachy)
 
   let callInformation = CallInformation(
     outputURL: outputURL,
@@ -137,7 +140,8 @@ let generate = command(
     developerDirURL: URL(fileURLWithPath: developerDirPath),
     sourceRootURL: URL(fileURLWithPath: sourceRootPath),
     sdkRootURL: URL(fileURLWithPath: sdkRootPath),
-    platformURL: URL(fileURLWithPath: platformPath)
+    platformURL: URL(fileURLWithPath: platformPath),
+    parsingInformation: parsingInfo
   )
 
   try RswiftCore.run(callInformation)

--- a/Sources/rswift/main.swift
+++ b/Sources/rswift/main.swift
@@ -77,7 +77,7 @@ struct CommanderOptions {
 // Options grouped in struct for readability
 struct CommanderArguments {
   static let outputDir = Argument<String>("outputDir", description: "Output directory for the 'R.generated.swift' file.")
-  static let useStringsHierachy = Flag.init("useStringsHierachy")
+  static let useStringsHierarchy = Flag.init("useStringsHierarchy")
 }
 
 let generate = command(
@@ -97,8 +97,8 @@ let generate = command(
   CommanderOptions.sdkRoot,
 
   CommanderArguments.outputDir,
-  CommanderArguments.useStringsHierachy
-) { importModules, accessLevel, rswiftIgnore, xcodeproj, target, bundle, productModule, buildProductsDir, developerDir, sourceRoot, sdkRoot, outputDir, useStringsHierachy in
+  CommanderArguments.useStringsHierarchy
+) { importModules, accessLevel, rswiftIgnore, xcodeproj, target, bundle, productModule, buildProductsDir, developerDir, sourceRoot, sdkRoot, outputDir, useStringsHierarchy in
 
   let info = ProcessInfo()
 
@@ -122,7 +122,7 @@ let generate = command(
     .map { Module.custom(name: $0) }
 
   //TODO: Support Json/Plist for other options, cause commander support 14 total parameters in call
-  let parsingInfo = ParsingInformation(useStringsHierarchy: useStringsHierachy)
+  let parsingInfo = ParsingInformation(useStringsHierarchy: useStringsHierarchy)
 
   let callInformation = CallInformation(
     outputURL: outputURL,


### PR DESCRIPTION
Usage (exactly like in ResourceApp while testing):
1) In build phase: 
```
"$SRCROOT/../build/Debug/rswift" generate "--useStringsHierarchy" "--import" "SWRevealViewController" "$SRCROOT" > "$SRCROOT/rswift.log"
```

2) In your *.strings file (localizable f.e.):
```
"myComponent.errors.catLoad" = "Unable to load component data";
"myComponent.errors.unknown" = "Unknown error";
"myComponent.title" = "Title";
```

3) In your code:
```
let strings = R.string.localizable.myComponent.self
showError(strings.errors.cantLoad())
```