### PR TITLE
Add mint support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,6 +3,9 @@ import PackageDescription
 
 let package = Package(
   name: "rswift",
+  products: [
+    .executable(name: "rswift", targets: ["rswift"]),
+  ],
   dependencies: [
     .package(url: "https://github.com/kylef/Commander.git", from: "0.8.0"),
     .package(url: "https://github.com/tomlokhorst/XcodeEdit", from: "2.5.0")

--- a/README.md
+++ b/README.md
@@ -103,6 +103,11 @@ _Screenshot of the Build Phase can be found [here](Documentation/Images/BuildPha
 
 _Tip:_ Add the `*.generated.swift` pattern to your `.gitignore` file to prevent unnecessary conflicts.
 
+### [Mint](https://github.com/yonaskolb/mint)
+```
+$ mint install mac-cain13/R.swift
+```
+
 ### Manually
 
 0. Add the [R.swift.Library](https://github.com/mac-cain13/R.swift.Library#Installation) to your project


### PR DESCRIPTION
If you don't use Cocoapods in your project, there is no proper way to manage the R.swift dependancy.

A dependency manager based on SwifPM called [Mint](https://github.com/yonaskolb/Mint) is ganning traction in the community and is already supported by some other swift based tools like Carthage or SwiftGen.

This PR just adds a product to Package.swift, the only required thing needed by Mint to work. 
To make R.swift installable via mint, a new Release of R.Swift will be needed