### PR TITLE
Fix for stand alone images not being listed as file resources.

### DIFF
--- a/Sources/RswiftCore/ResourceTypes/Resources.swift
+++ b/Sources/RswiftCore/ResourceTypes/Resources.swift
@@ -40,6 +40,9 @@ struct Resources {
         nibs.append(nib)
       } else if let image = tryResourceParsing({ try Image(url: url) }) {
         images.append(image)
+        if let resourceFile = tryResourceParsing({ try ResourceFile(url: url) }) {
+            resourceFiles.append(resourceFile)
+        }
       } else if let asset = tryResourceParsing({ try AssetFolder(url: url, fileManager: fileManager) }) {
         assetFolders.append(asset)
       } else if let font = tryResourceParsing({ try Font(url: url) }) {


### PR DESCRIPTION
### Undocumented breaking change
Under the 4.x line `R.generated.swift` would contain both an entry in both `image` and `file` for *stand alone* image files. This was very useful as many of Apple's API's require an image `URL` or path rather than just a `UIImage` object.

e.g.
```swift
/// This `R.file` struct is generated, and contains static references to 18 files.
  struct file {
    /// Resource file `notification-alert1.png`.
    static let notificationAlert1Png = Rswift.FileResource(bundle: R.hostingBundle, name: "notification-alert1", pathExtension: "png")
    /// Resource file `notification-alert2.png`.
    static let notificationAlert2Png = Rswift.FileResource(bundle: R.hostingBundle, name: "notification-alert2", pathExtension: "png")

    …and so on…

```

So usage in places like this are common place: 
```swift
UNNotificationAttachment.init(identifier: "",
                              url: R.file.notificationAlert1()!,
                              options: nil)
```

The change appeared in #451 with the commit 4fc7d553 - which was an optimisation to only iterate resource files once. The side effect was that images  not in an asset catalogue _only_ get added to `R.image`.

This PR contains a temporary fix we used to get the previous behaviour back.