### PR TITLE
Objective-C Support

### DIFF
--- a/ENV_VARS
+++ b/ENV_VARS
@@ -1,3 +1,7 @@
+Arguments:
+generate "../../ResourceApp/R.generated.swift" --objc
+
+Env Vars:
 PRODUCT_BUNDLE_IDENTIFIER=nl.mathijskadijk.ResourceApp
 SCRIPT_INPUT_FILE_COUNT=1
 SCRIPT_INPUT_FILE_0=./temp/rswift-lastrun

--- a/ENV_VARS
+++ b/ENV_VARS
@@ -1,0 +1,14 @@
+PRODUCT_BUNDLE_IDENTIFIER=nl.mathijskadijk.ResourceApp
+SCRIPT_INPUT_FILE_COUNT=1
+SCRIPT_INPUT_FILE_0=./temp/rswift-lastrun
+SCRIPT_OUTPUT_FILE_COUNT=1
+SCRIPT_OUTPUT_FILE_0=../../ResourceApp/R.generated.swift
+PLATFORM_DIR=/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform
+TEMP_DIR=./temp
+SDKROOT=/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator12.2.sdk
+SOURCE_ROOT=../../ResourceApp
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer
+BUILT_PRODUCTS_DIR=.
+PRODUCT_MODULE_NAME=ResourceApp
+PROJECT_FILE_PATH=../../ResourceApp/ResourceApp.xcodeproj
+TARGET_NAME=ResourceApp

--- a/R.swift.podspec
+++ b/R.swift.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "R.swift"
-  spec.version      = "5.0.5"
+  spec.version      = "5.0.6"
   spec.license      = "MIT"
 
   spec.summary      = "Get strong typed, autocompleted resources like images, fonts and segues in Swift projects"

--- a/R.swift.podspec
+++ b/R.swift.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "R.swift"
-  spec.version      = "5.0.3"
+  spec.version      = "5.0.4"
   spec.license      = "MIT"
 
   spec.summary      = "Get strong typed, autocompleted resources like images, fonts and segues in Swift projects"
@@ -21,7 +21,7 @@ Pod::Spec.new do |spec|
   spec.social_media_url   = "https://twitter.com/mac_cain13"
 
   spec.requires_arc = true
-  spec.source = { :http => "https://github.com/mac-cain13/R.swift/releases/download/v#{spec.version}/rswift-#{spec.version}.zip" }
+  spec.source = { :http => "https://github.com/bclymer/R.swift/releases/download/v#{spec.version}/rswift-#{spec.version}.zip" }
 
   spec.ios.deployment_target     = '8.0'
   spec.tvos.deployment_target    = '9.0'

--- a/R.swift.podspec
+++ b/R.swift.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "R.swift"
-  spec.version      = "5.0.4"
+  spec.version      = "5.0.5"
   spec.license      = "MIT"
 
   spec.summary      = "Get strong typed, autocompleted resources like images, fonts and segues in Swift projects"

--- a/Sources/RswiftCore/CallInformation.swift
+++ b/Sources/RswiftCore/CallInformation.swift
@@ -31,6 +31,7 @@ public struct CallInformation {
   let sourceRootURL: URL
   let sdkRootURL: URL
   let platformURL: URL
+  let objcCompat: Bool
 
   public init(
     outputURL: URL,
@@ -52,7 +53,8 @@ public struct CallInformation {
     developerDirURL: URL,
     sourceRootURL: URL,
     sdkRootURL: URL,
-    platformURL: URL
+    platformURL: URL,
+    objcCompat: Bool
   ) {
     self.outputURL = outputURL
     self.rswiftIgnoreURL = rswiftIgnoreURL
@@ -74,6 +76,7 @@ public struct CallInformation {
     self.sourceRootURL = sourceRootURL
     self.sdkRootURL = sdkRootURL
     self.platformURL = platformURL
+    self.objcCompat = objcCompat
   }
 
 

--- a/Sources/RswiftCore/CallInformation.swift
+++ b/Sources/RswiftCore/CallInformation.swift
@@ -32,6 +32,7 @@ public struct CallInformation {
   let sdkRootURL: URL
   let platformURL: URL
   let objcCompat: Bool
+  let unusedImages: Bool
 
   public init(
     outputURL: URL,
@@ -54,7 +55,8 @@ public struct CallInformation {
     sourceRootURL: URL,
     sdkRootURL: URL,
     platformURL: URL,
-    objcCompat: Bool
+    objcCompat: Bool,
+    unusedImages: Bool
   ) {
     self.outputURL = outputURL
     self.rswiftIgnoreURL = rswiftIgnoreURL
@@ -77,6 +79,7 @@ public struct CallInformation {
     self.sdkRootURL = sdkRootURL
     self.platformURL = platformURL
     self.objcCompat = objcCompat
+    self.unusedImages = unusedImages
   }
 
 

--- a/Sources/RswiftCore/ResourceTypes/Image.swift
+++ b/Sources/RswiftCore/ResourceTypes/Image.swift
@@ -12,6 +12,8 @@ import Foundation
 struct Image: WhiteListedExtensionsResourceType {
   // See "Supported Image Formats" on https://developer.apple.com/library/ios/documentation/UIKit/Reference/UIImage_Class/
   static let supportedExtensions: Set<String> = ["tiff", "tif", "jpg", "jpeg", "gif", "png", "bmp", "bmpf", "ico", "cur", "xbm"]
+  private static let extensions = Image.supportedExtensions.joined(separator: "|")
+  private static let regex = try! NSRegularExpression(pattern: "(~(ipad|iphone))?(@[2,3]x)?\\.(\(extensions))$", options: .caseInsensitive)
 
   let name: String
 
@@ -24,10 +26,8 @@ struct Image: WhiteListedExtensionsResourceType {
       throw ResourceParsingError.parsingFailed("Filename and/or extension could not be parsed from URL: \(url.absoluteString)")
     }
 
-    let extensions = Image.supportedExtensions.joined(separator: "|")
-    let regex = try! NSRegularExpression(pattern: "(~(ipad|iphone))?(@[2,3]x)?\\.(\(extensions))$", options: .caseInsensitive)
     let fullFileNameRange = NSRange(location: 0, length: filename.count)
     let pathExtensionToUse = (pathExtension == "png") ? "" : ".\(pathExtension)"
-    name = regex.stringByReplacingMatches(in: filename, options: NSRegularExpression.MatchingOptions(rawValue: 0), range: fullFileNameRange, withTemplate: pathExtensionToUse)
+    name = Image.regex.stringByReplacingMatches(in: filename, options: NSRegularExpression.MatchingOptions(rawValue: 0), range: fullFileNameRange, withTemplate: pathExtensionToUse)
   }
 }

--- a/Sources/RswiftCore/RswiftCore.swift
+++ b/Sources/RswiftCore/RswiftCore.swift
@@ -54,11 +54,21 @@ public struct RswiftCore {
           externalStruct,
           internalStruct
         ]
+        
+        let objcConvertibles: [ObjcCodeConvertible] = [
+            ObjcHeaderPrinter(),
+            externalStruct,
+            ObjcFooterPrinter(),
+        ]
 
-      let fileContents = codeConvertibles
+      var fileContents = codeConvertibles
         .compactMap { $0?.swiftCode }
         .joined(separator: "\n\n")
-        + "\n" // Newline at end of file
+        + "\n\n" // Newline at end of file
+      
+      if callInformation.objcCompat {
+        fileContents += objcConvertibles.compactMap { $0.objcCode(prefix: "") }.joined(separator: "\n") + "\n"
+      }
 
       // Write file if we have changes
       let currentFileContents = try? String(contentsOf: callInformation.outputURL, encoding: .utf8)

--- a/Sources/RswiftCore/RswiftCore.swift
+++ b/Sources/RswiftCore/RswiftCore.swift
@@ -69,6 +69,23 @@ public struct RswiftCore {
       if callInformation.objcCompat {
         fileContents += objcConvertibles.compactMap { $0.objcCode(prefix: "") }.joined(separator: "\n") + "\n"
       }
+    
+      if callInformation.unusedImages {
+        let allImages =
+          resources.images.map { $0.name } +
+          resources.assetFolders.flatMap { $0.imageAssets }
+
+        let allUsedImages =
+          resources.nibs.flatMap { $0.usedImageIdentifiers } +
+          resources.storyboards.flatMap { $0.usedImageIdentifiers }
+
+        let unusedImages = Set(allImages).subtracting(Set(allUsedImages))
+        let unusedImageGeneratedNames = unusedImages.map { SwiftIdentifier(name: $0).description }.uniqueAndSorted()
+
+        fileContents += "/* Potentially Unused Images\n"
+        fileContents += unusedImageGeneratedNames.joined(separator: "\n")
+        fileContents += "\n*/"
+      }
 
       // Write file if we have changes
       let currentFileContents = try? String(contentsOf: callInformation.outputURL, encoding: .utf8)

--- a/Sources/RswiftCore/SwiftTypes/CodeGenerators/ObjcHeaderPrinter.swift
+++ b/Sources/RswiftCore/SwiftTypes/CodeGenerators/ObjcHeaderPrinter.swift
@@ -14,10 +14,10 @@ struct ObjcHeaderPrinter: ObjcCodeConvertible {
             "//",
             "// Compatibility layer so resources can be used in ObjC",
             "//",
-            "",
             "@objcMembers",
             "@available(swift, obsoleted: 1.0, message: \"Use R. instead\")",
             "public class RObjc: Foundation.NSObject {",
+            "",
         ].joined(separator: "\n")
     }
 }
@@ -25,6 +25,9 @@ struct ObjcHeaderPrinter: ObjcCodeConvertible {
 /// Prints a static header for the beginning of the Objective-C portion of the file.
 struct ObjcFooterPrinter: ObjcCodeConvertible {
     func objcCode(prefix: String) -> String {
-        return "}"
+        return [
+            "  fileprivate override init() {}",
+            "}",
+        ].joined(separator: "\n")
     }
 }

--- a/Sources/RswiftCore/SwiftTypes/CodeGenerators/ObjcHeaderPrinter.swift
+++ b/Sources/RswiftCore/SwiftTypes/CodeGenerators/ObjcHeaderPrinter.swift
@@ -1,0 +1,30 @@
+//
+//  ObjcHeaderPrinter.swift
+//  RswiftCore
+//
+//  Created by Brian Clymer on 4/10/19.
+//
+
+import Foundation
+
+/// Prints a static header for the beginning of the Objective-C portion of the file.
+struct ObjcHeaderPrinter: ObjcCodeConvertible {
+    func objcCode(prefix: String) -> String {
+        return [
+            "//",
+            "// Compatibility layer so resources can be used in ObjC",
+            "//",
+            "",
+            "@objcMembers",
+            "@available(swift, obsoleted: 1.0, message: \"Use R. instead\")",
+            "public class RObjc: Foundation.NSObject {",
+        ].joined(separator: "\n")
+    }
+}
+
+/// Prints a static header for the beginning of the Objective-C portion of the file.
+struct ObjcFooterPrinter: ObjcCodeConvertible {
+    func objcCode(prefix: String) -> String {
+        return "}"
+    }
+}

--- a/Sources/RswiftCore/SwiftTypes/CodeGenerators/SwiftCodeConverible.swift
+++ b/Sources/RswiftCore/SwiftTypes/CodeGenerators/SwiftCodeConverible.swift
@@ -12,3 +12,7 @@ import Foundation
 protocol SwiftCodeConverible {
   var swiftCode: String { get }
 }
+
+protocol ObjcCodeConvertible {
+  func objcCode(prefix: String) -> String
+}

--- a/Sources/RswiftCore/SwiftTypes/Function.swift
+++ b/Sources/RswiftCore/SwiftTypes/Function.swift
@@ -45,35 +45,59 @@ struct Function: UsedTypesProvider, SwiftCodeConverible, ObjcCodeConvertible {
   }
     
   func objcCode(prefix: String) -> String {
-    guard returnType == Type._UIImage || returnType == Type._UIImage.asOptional() else { return "" }
-    //let commentsString = comments.map { "/// \($0)\n" }.joined(separator: "")
+    guard
+      name != "validate", // We won't be calling this from Objective-C code.
+      returnType.name != Type.TypedStoryboardSegueInfo.name, // This is a Swift only type.
+      !availables.contains(where: { $0.contains("deprecated") }), // Don't bring over deprecated functions.
+      !name.description.contains("`") // Don't convert functions with a name Objective-C can't understand
+    else {
+      return ""
+    }
     let availablesString = availables.map { "@available(\($0))\n" }.joined(separator: "")
     let accessModifierString = accessModifier.swiftCode
     let staticString = isStatic ? "static " : ""
     let genericsString = generics.map { "<\($0)>" } ?? ""
-    let parameterString = parameters.map { $0.description }.joined(separator: ", ")
-    let parameterInjection = parameters
-        .map {
-            let argName = ($0.name == "_") ? "" : "\($0.name): "
-            return "\(argName)\($0.localName ?? $0.name)"
-        }
-        .joined(separator: ", ")
+
+    let objcParams = parameters.filter { $0.type != Type._Void }
+    
+    let allParameterString = objcParams.map { $0.descriptionWithoutDefaultValue }.joined(separator: ", ")
+    let allParameterInjection = objcParams
+      .map {
+        let argName = ($0.name == "_") ? "" : "\($0.name): "
+        return "\(argName)\($0.localName ?? $0.name)"
+      }
+      .joined(separator: ", ")
+
+    // Required if the param is not optional, or there isn't a default value.
+    let requiredParams = objcParams.filter { !$0.type.optional || $0.defaultValue == nil }
+    let requiredParameterString = requiredParams.map { $0.descriptionWithoutDefaultValue }.joined(separator: ", ")
+    let requiredParameterInjection = requiredParams
+      .map {
+        let argName = ($0.name == "_") ? "" : "\($0.name): "
+        return "\(argName)\($0.localName ?? $0.name)"
+      }
+      .joined(separator: ", ")
+    
+    let shouldHaveShortenedFunction = requiredParams.count != objcParams.count
+    
     let throwString = doesThrow ? " throws" : ""
     let returnString = Type._Void == returnType ? "" : " -> \(returnType)"
-    //let bodyStringWithParams = "return \(prefix).\(name)(\(parameterInjection))".indent(with: "  ")
-    let bodyStringWithoutParams = "return \(prefix).\(name)()".indent(with: "  ")
+    let bodyStringAllParams = "return \(prefix).\(name)(\(allParameterInjection))"
+    let bodyStringRequiredParams = "return \(prefix).\(name)(\(requiredParameterInjection))"
     let functionName = "\(prefix)_\(name)"
-        .replacingOccurrences(of: ".", with: "_")
-        .replacingOccurrences(of: "R_", with: "")
+      .replacingOccurrences(of: ".", with: "_")
+      .replacingOccurrences(of: "R_", with: "")
     
-    // This is really all I need. Unsure if I should make all options available to Obj-C.
-    return "  \(availablesString)\(accessModifierString)\(staticString)func \(functionName)\(genericsString)()\(throwString)\(returnString){ \(bodyStringWithoutParams) }"
+    let commentsStringAllParams = bodyStringAllParams.replacingOccurrences(of: "return", with: "//")
+    let commentsStringRequiredParams = bodyStringRequiredParams.replacingOccurrences(of: "return", with: "//")
     
-//    let withParams = "\(commentsString)\(availablesString)\(accessModifierString)\(staticString)func \(functionName)\(genericsString)(\(parameterString))\(throwString)\(returnString) {\n\(bodyStringWithParams)\n}"
-//
-//    let withoutParams = "\(commentsString)\(availablesString)\(accessModifierString)\(staticString)func \(functionName)\(genericsString)()\(throwString)\(returnString) {\n\(bodyStringWithoutParams)\n}"
-//
-//    return "\(withParams)\n\n\(withoutParams)"
+    let requiredParamsFunction = "\(commentsStringRequiredParams)\n\(availablesString)\(accessModifierString)\(staticString)func \(functionName)\(genericsString)(\(requiredParameterString))\(throwString)\(returnString) {\n\(bodyStringRequiredParams.indent(with: "  "))\n}"
+    let allParamsFunction = "\(commentsStringAllParams)\n\(availablesString)\(accessModifierString)\(staticString)func \(functionName)\(genericsString)(\(allParameterString))\(throwString)\(returnString) {\n\(bodyStringAllParams.indent(with: "  "))\n}"
+    if shouldHaveShortenedFunction {
+      return "\(requiredParamsFunction)\n\n\(allParamsFunction)\n"
+    } else {
+      return "\(allParamsFunction)\n"
+    }
   }
 
   struct Parameter: UsedTypesProvider, CustomStringConvertible {
@@ -91,8 +115,11 @@ struct Function: UsedTypesProvider, SwiftCodeConverible, ObjcCodeConvertible {
     }
 
     var description: String {
-      let definition = localName.map({ "\(swiftIdentifier) \($0): \(type)" }) ?? "\(swiftIdentifier): \(type)"
-      return defaultValue.map({ "\(definition) = \($0)" }) ?? definition
+      return defaultValue.map({ "\(descriptionWithoutDefaultValue) = \($0)" }) ?? descriptionWithoutDefaultValue
+    }
+    
+    var descriptionWithoutDefaultValue: String {
+        return localName.map({ "\(swiftIdentifier) \($0): \(type)" }) ?? "\(swiftIdentifier): \(type)"
     }
 
     init(name: String, type: Type, defaultValue: String? = nil) {

--- a/Sources/RswiftCore/SwiftTypes/Struct.swift
+++ b/Sources/RswiftCore/SwiftTypes/Struct.swift
@@ -85,25 +85,27 @@ struct Struct: UsedTypesProvider, SwiftCodeConverible, ObjcCodeConvertible {
     return "\(commentsString)\(availablesString)\(accessModifierString)struct \(type)\(implementsString) {\n\(bodyString)\n}"
   }
     
-    func objcCode(prefix: String) -> String {
-        
-        let maybeDot = prefix.isEmpty ? "" : "."
-        let newPrefix = "\(prefix)\(maybeDot)\(type.name.description)"
-        
-        let functionsString = functions
-            .map { $0.objcCode(prefix: newPrefix) }
-            .sorted()
-            .map { $0.description }
-            .filter { !$0.isEmpty }
-            .joined(separator: "\n")
-        
-        let structsString = structs
-            .map { $0.objcCode(prefix: newPrefix) }
-            .sorted()
-            .map { $0.description }
-            .filter { !$0.isEmpty }
-            .joined(separator: "\n")
-        
-        return functionsString + structsString
-    }
+  func objcCode(prefix: String) -> String {
+    
+    let isInitialStruct = prefix.isEmpty
+    let maybeDot = isInitialStruct ? "" : "."
+    let newPrefix = "\(prefix)\(maybeDot)\(type.name.description)"
+    
+    let functionsString = functions
+        .map { $0.objcCode(prefix: newPrefix) }
+        .sorted()
+        .map { $0.description }
+        .filter { !$0.isEmpty }
+        .joined(separator: "\n")
+    
+    let structsString = structs
+        .map { $0.objcCode(prefix: newPrefix) }
+        .sorted()
+        .map { $0.description }
+        .filter { !$0.isEmpty }
+        .joined(separator: "\n")
+        .indent(with: isInitialStruct ? "  " : "")
+    
+    return functionsString + structsString
+  }
 }

--- a/Sources/RswiftCore/SwiftTypes/Struct.swift
+++ b/Sources/RswiftCore/SwiftTypes/Struct.swift
@@ -9,7 +9,7 @@
 
 import Foundation
 
-struct Struct: UsedTypesProvider, SwiftCodeConverible {
+struct Struct: UsedTypesProvider, SwiftCodeConverible, ObjcCodeConvertible {
   let availables: [String]
   let comments: [String]
   let accessModifier: AccessLevel
@@ -84,4 +84,26 @@ struct Struct: UsedTypesProvider, SwiftCodeConverible {
 
     return "\(commentsString)\(availablesString)\(accessModifierString)struct \(type)\(implementsString) {\n\(bodyString)\n}"
   }
+    
+    func objcCode(prefix: String) -> String {
+        
+        let maybeDot = prefix.isEmpty ? "" : "."
+        let newPrefix = "\(prefix)\(maybeDot)\(type.name.description)"
+        
+        let functionsString = functions
+            .map { $0.objcCode(prefix: newPrefix) }
+            .sorted()
+            .map { $0.description }
+            .filter { !$0.isEmpty }
+            .joined(separator: "\n")
+        
+        let structsString = structs
+            .map { $0.objcCode(prefix: newPrefix) }
+            .sorted()
+            .map { $0.description }
+            .filter { !$0.isEmpty }
+            .joined(separator: "\n")
+        
+        return functionsString + structsString
+    }
 }

--- a/Sources/RswiftCore/Util/Glob.swift
+++ b/Sources/RswiftCore/Util/Glob.swift
@@ -60,8 +60,6 @@ public class Glob: Collection {
 
   public static let defaultBlacklistedDirectories = ["node_modules", "Pods"]
 
-  private var isDirectoryCache = [String: Bool]()
-
   public let behavior: Behavior
   public let blacklistedDirectories: [String]
   var paths = [String]()
@@ -105,8 +103,6 @@ public class Glob: Collection {
     paths = Array(Set(paths)).sorted { lhs, rhs in
       lhs.compare(rhs) != ComparisonResult.orderedDescending
     }
-
-    clearCaches()
   }
   
   // MARK: Subscript Support
@@ -187,19 +183,8 @@ public class Glob: Collection {
   }
 
   private func isDirectory(path: String) -> Bool {
-    if let isDirectory = isDirectoryCache[path] {
-      return isDirectory
-    }
-
     var isDirectoryBool = ObjCBool(false)
-    let isDirectory = FileManager.default.fileExists(atPath: path, isDirectory: &isDirectoryBool) && isDirectoryBool.boolValue
-    isDirectoryCache[path] = isDirectory
-
-    return isDirectory
-  }
-
-  private func clearCaches() {
-    isDirectoryCache.removeAll()
+    return FileManager.default.fileExists(atPath: path, isDirectory: &isDirectoryBool) && isDirectoryBool.boolValue
   }
 
   private func populateFiles(gt: glob_t, includeFiles: Bool) {

--- a/Sources/RswiftCore/Util/SwiftIdentifier.swift
+++ b/Sources/RswiftCore/Util/SwiftIdentifier.swift
@@ -160,7 +160,7 @@ private let blacklistedCharacters: CharacterSet = {
 }()
 
 // Based on https://docs.swift.org/swift-book/ReferenceManual/LexicalStructure.html#ID413
-private let SwiftKeywords = [
+private let SwiftKeywords = Set([
   // Keywords used in declarations
   "associatedtype", "class", "deinit", "enum", "extension", "fileprivate", "func", "import", "init", "inout", "internal", "let", "open", "operator", "private", "protocol", "public", "static", "struct", "subscript", "typealias", "var",
 
@@ -175,5 +175,4 @@ private let SwiftKeywords = [
 
   // Keywords from Swift 2 that are still reserved
   "__COLUMN__", "__FILE__", "__FUNCTION__", "__LINE__",
-]
-
+])

--- a/Sources/rswift/main.swift
+++ b/Sources/rswift/main.swift
@@ -37,6 +37,7 @@ extension ProcessInfo {
 struct CommanderFlags {
   static let version = Flag("version", description: "Prints version information about this release.")
   static let objc = Flag("objc", description: "Generates ObjC compatible definitions in RObjc")
+  static let unusedImages = Flag("unused-images", description: "Appends a list of images that aren't used in xibs or storyboards to check against if they are still used.")
 }
 
 // Default values for non-optional Commander Options
@@ -84,9 +85,10 @@ let generate = command(
   CommanderOptions.inputOutputFilesValidation,
   
   CommanderFlags.objc,
+  CommanderFlags.unusedImages,
 
   CommanderArguments.outputPath
-) { importModules, accessLevel, rswiftIgnore, inputOutputFilesValidation, objc, outputPath in
+) { importModules, accessLevel, rswiftIgnore, inputOutputFilesValidation, objc, unusedImages, outputPath in
 
   let processInfo = ProcessInfo()
 
@@ -179,7 +181,8 @@ let generate = command(
     sourceRootURL: URL(fileURLWithPath: sourceRootPath),
     sdkRootURL: URL(fileURLWithPath: sdkRootPath),
     platformURL: URL(fileURLWithPath: platformPath),
-    objcCompat: objc
+    objcCompat: objc,
+    unusedImages: unusedImages
   )
 
   try RswiftCore.run(callInformation)

--- a/Sources/rswift/main.swift
+++ b/Sources/rswift/main.swift
@@ -36,6 +36,7 @@ extension ProcessInfo {
 // Flags grouped in struct for readability
 struct CommanderFlags {
   static let version = Flag("version", description: "Prints version information about this release.")
+  static let objc = Flag("objc", description: "Generates ObjC compatible definitions in RObjc")
 }
 
 // Default values for non-optional Commander Options
@@ -81,9 +82,11 @@ let generate = command(
   CommanderOptions.accessLevel,
   CommanderOptions.rswiftIgnore,
   CommanderOptions.inputOutputFilesValidation,
+  
+  CommanderFlags.objc,
 
   CommanderArguments.outputPath
-) { importModules, accessLevel, rswiftIgnore, inputOutputFilesValidation, outputPath in
+) { importModules, accessLevel, rswiftIgnore, inputOutputFilesValidation, objc, outputPath in
 
   let processInfo = ProcessInfo()
 
@@ -175,7 +178,8 @@ let generate = command(
     developerDirURL: URL(fileURLWithPath: developerDirPath),
     sourceRootURL: URL(fileURLWithPath: sourceRootPath),
     sdkRootURL: URL(fileURLWithPath: sdkRootPath),
-    platformURL: URL(fileURLWithPath: platformPath)
+    platformURL: URL(fileURLWithPath: platformPath),
+    objcCompat: objc
   )
 
   try RswiftCore.run(callInformation)


### PR DESCRIPTION
## Pre-Read

This PR isn't 100% ready to be merged. For example, `ENV_VARS` still exists, the `.podspec` still points to my fork, etc. This PR is just going up in order to:

1) Promote discussion about the possibility of Objective-C support for the main R.swift repo.
2) Welcome normal code review feedback.

If the concept is accepted, I will get another branch that excludes some of the unnecessary changes up and ready.

## What Is This?

This PR adds support for generating Objective-C compatible code that directly references the existing generated Swift code. For example, in Swift you can access an image like so:

```
R.image.conflicting()
```
Now, in Objective-C you can call
```
[RObjc image_conflicting];
```
and you will get the same `UIImage?` back.

You can also call
```
[RObjc image_conflictingWithCompatibleWith:traitCollection];
```
Two Objective-C compatible functions get generated for most Swift functions. The first with the minimal amount of parameters, and the other with all parameters. Since Objective-C doesn't have default values, this cleans up usage significantly. In the case where the minimum number of parameters is equal to all parameters (such as strings with required formatting inputs), only one function is generated.

The same type of support exists for all types that R.swift supports with the exception of `TypedStoryboardSegueInfo` for obvious incompatibility reasons.

## How Do I Use It?

Generating Objective-C compatible code is possible by appending `--objc` to your command line arguments. This means the generate is **opt-in** and will not affect most projects.

As stated above, most existing `R.x.y` calls have been ported to `[RObjc x_y]`. It should be as simple as adding `#import Project-Swift.h` to the Objective-C file you want to utilize R.swift in.

In addition, the generated header contains `@available(swift, obsoleted: 1.0, message: "Use R. instead")`, preventing Swift usage of the Objective-C compatible code.

## Limitations

### TypedStoryboardSegueInfo

As mentioned above, this type of structure isn't compatible with Objective-C, so these are excluded.

### Invalid File Names

Files with invalid names are not generated. For example the following will not be ported.
```
static func `__FILE__`(_: Void = ()) -> Foundation.URL?
```

### Validate Functions

Validate functions are not ported. I really just didn't see the point in doing it. I think it would be trivial to add back.

### Deprecated Functions

They're deprecated anyway, so why port them?

## Example R.generated.swift

This is only the Objective-C compatible part, it is created from the example app provided in the repo.

https://gist.github.com/bclymer/fa19c0b7260cc561b8dfce2b0e26385a