### PR TITLE
Make R.Swift compatible with Swift 5.0

### DIFF
--- a/Sources/RswiftCore/Generators/NibStructGenerator.swift
+++ b/Sources/RswiftCore/Generators/NibStructGenerator.swift
@@ -37,7 +37,7 @@ struct NibStructGenerator: StructGenerator {
 
   private let instantiateParameters = [
     Function.Parameter(name: "owner", localName: "ownerOrNil", type: Type._AnyObject.asOptional()),
-    Function.Parameter(name: "options", localName: "optionsOrNil", type: Type(module: .stdLib, name: SwiftIdentifier(rawValue: "[UINib.OptionsKey : Any]"), optional: true), defaultValue: "nil")
+    Function.Parameter(name: "options", localName: "optionsOrNil", type: Type(module: .stdLib, name: SwiftIdentifier(rawValue: "[NSString : Any]"), optional: true), defaultValue: "nil")
   ]
 
   init(nibs: [Nib]) {


### PR DESCRIPTION
When trying to compile the R.generated swift file code with Swift 5.0 I stumbled upon the following error:

![Screenshot 2019-06-13 at 13 09 23](https://user-images.githubusercontent.com/15321233/59424440-ab6ed600-8ddc-11e9-81a7-bd100ee3b59f.png)

Therefore, I changed the `NibStructGenerator` to generate `NSString `as key dictionary of the `optionsOrNi`l parameter instead of `UINIb.OptionsKey` type which fixes the compile error.