### PR TITLE
Reorder Module Imports in Generated Source Code

### DIFF
--- a/Sources/RswiftCore/CallInformation.swift
+++ b/Sources/RswiftCore/CallInformation.swift
@@ -16,7 +16,7 @@ public struct CallInformation {
   let rswiftIgnoreURL: URL
 
   let accessLevel: AccessLevel
-  let imports: Set<Module>
+  let imports: [Module]
 
   let xcodeprojURL: URL
   let targetName: String
@@ -39,7 +39,7 @@ public struct CallInformation {
     rswiftIgnoreURL: URL,
 
     accessLevel: AccessLevel,
-    imports: Set<Module>,
+    imports: [Module],
 
     xcodeprojURL: URL,
     targetName: String,

--- a/Sources/RswiftCore/SwiftTypes/CodeGenerators/ImportPrinter.swift
+++ b/Sources/RswiftCore/SwiftTypes/CodeGenerators/ImportPrinter.swift
@@ -13,19 +13,22 @@ import Foundation
 struct ImportPrinter: SwiftCodeConverible {
   let swiftCode: String
 
-  init(modules: Set<Module>, extractFrom structs: [Struct?], exclude excludedModules: Set<Module>) {
+  init(modules: [Module], extractFrom structs: [Struct?], exclude excludedModules: Set<Module>) {
     let extractedModules = structs
       .compactMap { $0 }
       .flatMap(getUsedTypes)
       .map { $0.type.module }
 
-    let modulesSet = modules
-      .union(extractedModules)
+    let extractedModulesArray = Set(extractedModules)
       .subtracting(excludedModules)
-
-    swiftCode = Array(modulesSet)
+      .subtracting(modules)
       .filter { $0.isCustom }
       .sorted { $0.description < $1.description }
+
+    var modulesToImport = modules
+    modulesToImport.append(contentsOf: extractedModulesArray)
+
+    swiftCode = modulesToImport
       .map { "import \($0)" }
       .joined(separator: "\n")
   }

--- a/Sources/rswift/main.swift
+++ b/Sources/rswift/main.swift
@@ -165,7 +165,7 @@ let generate = command(
     rswiftIgnoreURL: rswiftIgnoreURL,
 
     accessLevel: accessLevel,
-    imports: Set(modules),
+    imports: modules,
 
     xcodeprojURL: URL(fileURLWithPath: xcodeprojPath),
     targetName: targetName,


### PR DESCRIPTION
I updated `ImportPrinter` to change the order of the imports that are
generated in the output source code. Previously all imports were being
sorted alphabetically and then output to the generated source code. This
was a problem if `R.swift.library` is being statically linked in another
dynamic framework and the containing framework's module name is
alphabetically after the `Rswift` module name. In this case, the Swift
compiler does not correctly import the `Rswift` module.

I changed `ImportPrinter` to always output modules that are specified
using the `--import` command line argument before modules that are
extracted from the source code. This should fix the import issue.

I updated `CallInformation.swift` to pass the list of modules as an array
instead of a set in order to keep the order in which they were specified
on the command line in order to ensure proper ordering of imports in
the generated source code.

Resolves #534 