### PR TITLE
Add Mint Support (Includes Updated Documentation)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ rswift.xcodeproj
 .build
 build
 DerivedData
+.swiftpm

--- a/Package.swift
+++ b/Package.swift
@@ -6,6 +6,9 @@ let package = Package(
   platforms: [
     .macOS(.v10_11)
   ],
+  products: [
+    .executable(name: "rswift", targets: ["rswift"])
+  ],
   dependencies: [
     .package(url: "https://github.com/kylef/Commander.git", from: "0.8.0"),
     .package(url: "https://github.com/tomlokhorst/XcodeEdit", from: "2.7.0")

--- a/README.md
+++ b/README.md
@@ -104,9 +104,32 @@ _Screenshot of the Build Phase can be found [here](Documentation/Images/BuildPha
 _Tip:_ Add the `*.generated.swift` pattern to your `.gitignore` file to prevent unnecessary conflicts.
 
 ### [Mint](https://github.com/yonaskolb/mint)
-```
-$ mint install mac-cain13/R.swift
-```
+
+#### First, Install `R.Swift` Binary and Run Script Phase
+
+1. Add `mac-cain13/R.swift` to your [Mintfile](https://github.com/yonaskolb/Mint#mintfile) and run `mint bootstrap`  to install this package without linking it globally (recommended)
+2. In Xcode: Click on your project in the file list, choose your target under `TARGETS`, click the `Build Phases` tab and add a `New Run Script Phase` by clicking the little plus icon in the top left
+3. Drag the new `Run Script` phase **above** the `Compile Sources` phase, expand it and paste the following script:  
+   ```
+   if mint list | grep -q 'R.swift'; then
+     mint run R.swift rswift generate "$SRCROOT/R.generated.swift"
+   else
+     echo "error: R.swift not installed; run 'mint bootstrap' to install"
+     return -1
+   fi
+   ```
+4. Add `$TEMP_DIR/rswift-lastrun` to the "Input Files" and `$SRCROOT/R.generated.swift` to the "Output Files" of the Build Phase
+5. Build your project, in Finder you will now see a `R.generated.swift` in the `$SRCROOT`-folder, drag the `R.generated.swift` files into your project and **uncheck** `Copy items if needed`
+
+_Screenshot of the Build Phase can be found [here](Documentation/Images/BuildPhaseExample.png)_
+
+_Tip:_ Add the `*.generated.swift` pattern to your `.gitignore` file to prevent unnecessary conflicts.
+
+#### Second, Install `R.Swift.Library` via the Swift Package Manager (requires Xcode 11)
+
+If you see a build error `No such module 'Rswift'` when trying to `#import Rswift` at the top of the `R.generated.swift` file, then you will also need to install the *library* via the Swift Package Manager available in Xcode 11+.
+
+Head over to the [R.Swift.Library](https://github.com/mac-cain13/R.swift.Library) repo and follow the [Swift Package Manager installation instructions](https://github.com/mac-cain13/R.swift.Library#swift-package-manager-requires-xcode-11).
 
 ### Manually
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,11 @@ _Screenshot of the Build Phase can be found [here](Documentation/Images/BuildPha
 
 _Tip:_ Add the `*.generated.swift` pattern to your `.gitignore` file to prevent unnecessary conflicts.
 
+### [Mint](https://github.com/yonaskolb/mint)
+```
+$ mint install mac-cain13/R.swift
+```
+
 ### Manually
 
 0. Add the [R.swift.Library](https://github.com/mac-cain13/R.swift.Library#Installation) to your project


### PR DESCRIPTION
This PR includes the previous pull request from @lilpit and adds the following modifications:

- provides the additional documentation requested by @mac-cain13 in the original PR review
- adds .swiftpm to the .gitignore file (pretty sure this should be ignored)

As a refresher, @lilpit submitted #485 :

> If you don't use Cocoapods in your project, there is no proper way to manage the R.swift dependancy.
> 
> A dependency manager based on SwifPM called Mint is ganning traction in the community and is already supported by some other swift based tools like Carthage or SwiftGen.
> 
> This PR just adds a product to Package.swift, the only required thing needed by Mint to work.
> To make R.swift installable via mint, a new Release of R.Swift will be needed

**NOTE**: My `R.Swift.Library` [Pull Request 34](https://github.com/mac-cain13/R.swift.Library/pull/34) should also be accepted (probably first) because it is required for the instructions in part 2 here.

Thanks!