### PR TITLE
Restore fonts in R.file

### DIFF
--- a/Sources/RswiftCore/ResourceTypes/Resources.swift
+++ b/Sources/RswiftCore/ResourceTypes/Resources.swift
@@ -40,19 +40,19 @@ struct Resources {
         nibs.append(nib)
       } else if let image = tryResourceParsing({ try Image(url: url) }) {
         images.append(image)
-        if let resourceFile = tryResourceParsing({ try ResourceFile(url: url) }) {
-            resourceFiles.append(resourceFile)
-        }
       } else if let asset = tryResourceParsing({ try AssetFolder(url: url, fileManager: fileManager) }) {
         assetFolders.append(asset)
       } else if let font = tryResourceParsing({ try Font(url: url) }) {
         fonts.append(font)
       } else if let storyboard = tryResourceParsing({ try Storyboard(url: url) }) {
         storyboards.append(storyboard)
-      } else if let resourceFile = tryResourceParsing({ try ResourceFile(url: url) }) {
-        resourceFiles.append(resourceFile)
       } else if let localizableString = tryResourceParsing({ try LocalizableStrings(url: url) }) {
         localizableStrings.append(localizableString)
+      }
+
+      // All previous assets can also possibly be used as files
+      if let resourceFile = tryResourceParsing({ try ResourceFile(url: url) }) {
+        resourceFiles.append(resourceFile)
       }
     }
     


### PR DESCRIPTION
Fixes: https://github.com/mac-cain13/R.swift/issues/498

In R.swift 4, standalone images would exist under R.image and R.file and fonts under R.font and R.file.
R.swift 5.0 changed this (accidentally) so images would only be under R.image. This was previously fixed. This PR also fixes it for fonts (and other assets).

This only adds different types to R.file (if applicable), because it was the only type I could think of that includes assets that also appear somewhere else.
If there's more types that include multiple assets, we should fix this more generally (by replacing all `else if let` with `if let`)