### PR TITLE
Add developmentRegion after Base as default language

### DIFF
--- a/Sources/RswiftCore/Generators/AggregatedStructGenerator.swift
+++ b/Sources/RswiftCore/Generators/AggregatedStructGenerator.swift
@@ -30,6 +30,7 @@ class AggregatedStructGenerator: StructGenerator {
         return result
       }
       .reduce(StructGeneratorResultCollector()) { collector, result in collector.appending(result) }
+      .sorted
 
     let externalStruct = Struct(
       availables: [],
@@ -81,6 +82,13 @@ private struct StructGeneratorResultCollector {
     return StructGeneratorResultCollector(
       externalStructs: externalStructs + [result.externalStruct],
       internalStructs: internalStructs + [result.internalStruct].compactMap { $0 }
+    )
+  }
+
+  var sorted: StructGeneratorResultCollector {
+    return StructGeneratorResultCollector(
+      externalStructs: externalStructs.sorted(by: { $0.type.name.description < $1.type.name.description }),
+      internalStructs: internalStructs.sorted(by: { $0.type.name.description < $1.type.name.description })
     )
   }
 }

--- a/Sources/RswiftCore/Generators/StringsStructGenerator.swift
+++ b/Sources/RswiftCore/Generators/StringsStructGenerator.swift
@@ -119,6 +119,24 @@ struct StringsStructGenerator: ExternalOnlyStructGenerator {
       warn("Strings file \(filenameLocale) is missing translations for keys: \(paddedKeysString)")
     }
 
+    // Warnings about extra translations
+    for (locale, lss) in strings.grouped(by: { $0.locale }) {
+      let filenameLocale = locale.withFilename(filename)
+      let sourceKeys = developmentKeys ?? Set(allParams.keys)
+
+      let usedKeys = Set(lss.flatMap { $0.dictionary.keys })
+      let extra = usedKeys.subtracting(sourceKeys)
+
+      if extra.isEmpty {
+        continue
+      }
+
+      let paddedKeys = extra.sorted().map { "'\($0)'" }
+      let paddedKeysString = paddedKeys.joined(separator: ", ")
+
+      warn("Strings file \(filenameLocale) has extra translations (not in \(developmentLanguage)) for keys: \(paddedKeysString)")
+    }
+
     // Only include translation if it exists in the development language
     func includeTranslation(_ key: String) -> Bool {
       if let developmentKeys = developmentKeys {

--- a/Sources/RswiftCore/ResourceTypes/Locale.swift
+++ b/Sources/RswiftCore/ResourceTypes/Locale.swift
@@ -11,6 +11,7 @@ import Foundation
 
 enum Locale {
   case none
+  case base // Older projects use a "Base" locale
   case language(String)
 
   var isNone: Bool {
@@ -21,7 +22,15 @@ enum Locale {
     return false
   }
 
-    var language: String? {
+  var isBase: Bool {
+    if case .base = self {
+      return true
+    }
+
+    return false
+  }
+
+  var language: String? {
     if case .language(let language) = self {
       return language
     }
@@ -35,7 +44,11 @@ extension Locale: Hashable {
     if let localeComponent = url.pathComponents.dropLast().last , localeComponent.hasSuffix(".lproj") {
       let lang = localeComponent.replacingOccurrences(of: ".lproj", with: "")
 
-      self = .language(lang)
+      if lang == "Base" {
+        self = .base
+      } else {
+        self = .language(lang)
+      }
     }
     else {
       self = .none
@@ -46,6 +59,9 @@ extension Locale: Hashable {
     switch self {
     case .none:
       return nil
+
+    case .base:
+      return "Base"
 
     case .language(let language):
       return language

--- a/Sources/RswiftCore/ResourceTypes/Locale.swift
+++ b/Sources/RswiftCore/ResourceTypes/Locale.swift
@@ -11,16 +11,7 @@ import Foundation
 
 enum Locale {
   case none
-  case base
   case language(String)
-
-  var isBase: Bool {
-    if case .base = self {
-      return true
-    }
-
-    return false
-  }
 
   var isNone: Bool {
     if case .none = self {
@@ -29,6 +20,14 @@ enum Locale {
 
     return false
   }
+
+    var language: String? {
+    if case .language(let language) = self {
+      return language
+    }
+
+    return nil
+  }
 }
 
 extension Locale: Hashable {
@@ -36,12 +35,7 @@ extension Locale: Hashable {
     if let localeComponent = url.pathComponents.dropLast().last , localeComponent.hasSuffix(".lproj") {
       let lang = localeComponent.replacingOccurrences(of: ".lproj", with: "")
 
-      if lang == "Base" {
-        self = .base
-      }
-      else {
-        self = .language(lang)
-      }
+      self = .language(lang)
     }
     else {
       self = .none
@@ -52,9 +46,6 @@ extension Locale: Hashable {
     switch self {
     case .none:
       return nil
-
-    case .base:
-      return "Base"
 
     case .language(let language):
       return language

--- a/Sources/RswiftCore/ResourceTypes/Xcodeproj.swift
+++ b/Sources/RswiftCore/ResourceTypes/Xcodeproj.swift
@@ -15,6 +15,8 @@ struct Xcodeproj: WhiteListedExtensionsResourceType {
 
   private let projectFile: XCProjectFile
 
+  let developmentLanguage: String
+
   init(url: URL) throws {
     try Xcodeproj.throwIfUnsupportedExtension(url.pathExtension)
     let projectFile: XCProjectFile
@@ -35,6 +37,7 @@ struct Xcodeproj: WhiteListedExtensionsResourceType {
     }
 
     self.projectFile = projectFile
+    self.developmentLanguage = projectFile.project.developmentRegion
   }
 
   func resourcePathsForTarget(_ targetName: String) throws -> [Path] {

--- a/Sources/RswiftCore/RswiftCore.swift
+++ b/Sources/RswiftCore/RswiftCore.swift
@@ -39,7 +39,7 @@ public struct RswiftCore {
         NibStructGenerator(nibs: resources.nibs),
         ReuseIdentifierStructGenerator(reusables: resources.reusables),
         ResourceFileStructGenerator(resourceFiles: resources.resourceFiles),
-        StringsStructGenerator(localizableStrings: resources.localizableStrings),
+        StringsStructGenerator(localizableStrings: resources.localizableStrings, developmentLanguage: xcodeproj.developmentLanguage),
         AccessibilityIdentifierStructGenerator(nibs: resources.nibs, storyboards: resources.storyboards),
       ])
       writeIfChanged(contents: fileContents, toURL: callInformation.outputURL)


### PR DESCRIPTION
When generating comments for R.string, use developmentRegion from the Xcode project as fallback when no Base region is set.

Add warning about extra translation in non-base/development languages.

Fixes: https://github.com/mac-cain13/R.swift/issues/539