### PR TITLE
Localised Strings in addition to Locale.preferredLanguages

### DIFF
--- a/LocalizedStringApp/LocalizedStringApp.xcodeproj/project.pbxproj
+++ b/LocalizedStringApp/LocalizedStringApp.xcodeproj/project.pbxproj
@@ -1,0 +1,677 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 50;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		4BBE4418B51EC4EA7E8ED322 /* libPods-LocalizedStringApp.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9E8A7683B1C7BA67F4482933 /* libPods-LocalizedStringApp.a */; };
+		76F4720C6B697E9677FA72D7 /* libPods-LocalizedStringAppTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B0E837DDBD8F520F45BD3C01 /* libPods-LocalizedStringAppTests.a */; };
+		E264FBA12319055A008E0DB5 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E264FBA02319055A008E0DB5 /* AppDelegate.swift */; };
+		E264FBB82319055D008E0DB5 /* LocalizedStringAppTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E264FBB72319055D008E0DB5 /* LocalizedStringAppTests.swift */; };
+		E264FBCF2319082F008E0DB5 /* one.strings in Resources */ = {isa = PBXBuildFile; fileRef = E264FBCE2319082E008E0DB5 /* one.strings */; };
+		E264FBD22319083B008E0DB5 /* two.strings in Resources */ = {isa = PBXBuildFile; fileRef = E264FBD02319083B008E0DB5 /* two.strings */; };
+		E264FBD523190962008E0DB5 /* three.strings in Resources */ = {isa = PBXBuildFile; fileRef = E264FBD323190962008E0DB5 /* three.strings */; };
+		E264FBD923190992008E0DB5 /* four.strings in Resources */ = {isa = PBXBuildFile; fileRef = E264FBD723190992008E0DB5 /* four.strings */; };
+		E264FBDD231909F6008E0DB5 /* five.strings in Resources */ = {isa = PBXBuildFile; fileRef = E264FBDB231909F6008E0DB5 /* five.strings */; };
+		E264FBE223190A19008E0DB5 /* six.strings in Resources */ = {isa = PBXBuildFile; fileRef = E264FBE023190A19008E0DB5 /* six.strings */; };
+		E264FBE623190A2F008E0DB5 /* seven.strings in Resources */ = {isa = PBXBuildFile; fileRef = E264FBE423190A2F008E0DB5 /* seven.strings */; };
+		E264FBEB23190A49008E0DB5 /* eight.strings in Resources */ = {isa = PBXBuildFile; fileRef = E264FBE923190A49008E0DB5 /* eight.strings */; };
+		E264FBF023190BD4008E0DB5 /* R.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = E264FBEF23190BD4008E0DB5 /* R.generated.swift */; };
+		E264FBF4231A7335008E0DB5 /* nine.strings in Resources */ = {isa = PBXBuildFile; fileRef = E264FBF6231A7335008E0DB5 /* nine.strings */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		E264FBB42319055D008E0DB5 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = E264FB952319055A008E0DB5 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = E264FB9C2319055A008E0DB5;
+			remoteInfo = LocalizedStringApp;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		1D03B0D9A8F18724B68DD0FB /* Pods-LocalizedStringApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-LocalizedStringApp.debug.xcconfig"; path = "Target Support Files/Pods-LocalizedStringApp/Pods-LocalizedStringApp.debug.xcconfig"; sourceTree = "<group>"; };
+		2B3837A07F59517ABA7B025C /* Pods-LocalizedStringAppTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-LocalizedStringAppTests.release.xcconfig"; path = "Target Support Files/Pods-LocalizedStringAppTests/Pods-LocalizedStringAppTests.release.xcconfig"; sourceTree = "<group>"; };
+		388F2C098F37BE577962EE06 /* Pods-LocalizedStringAppTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-LocalizedStringAppTests.debug.xcconfig"; path = "Target Support Files/Pods-LocalizedStringAppTests/Pods-LocalizedStringAppTests.debug.xcconfig"; sourceTree = "<group>"; };
+		9E8A7683B1C7BA67F4482933 /* libPods-LocalizedStringApp.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-LocalizedStringApp.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		B0E837DDBD8F520F45BD3C01 /* libPods-LocalizedStringAppTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-LocalizedStringAppTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		C6B891777D84DD950FA5FFB4 /* Pods-LocalizedStringApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-LocalizedStringApp.release.xcconfig"; path = "Target Support Files/Pods-LocalizedStringApp/Pods-LocalizedStringApp.release.xcconfig"; sourceTree = "<group>"; };
+		E264FB9D2319055A008E0DB5 /* LocalizedStringApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = LocalizedStringApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		E264FBA02319055A008E0DB5 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		E264FBAE2319055D008E0DB5 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		E264FBB32319055D008E0DB5 /* LocalizedStringAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = LocalizedStringAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		E264FBB72319055D008E0DB5 /* LocalizedStringAppTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalizedStringAppTests.swift; sourceTree = "<group>"; };
+		E264FBB92319055D008E0DB5 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		E264FBCE2319082E008E0DB5 /* one.strings */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; path = one.strings; sourceTree = "<group>"; };
+		E264FBD12319083B008E0DB5 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/two.strings; sourceTree = "<group>"; };
+		E264FBD423190962008E0DB5 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/three.strings; sourceTree = "<group>"; };
+		E264FBD62319096F008E0DB5 /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/three.strings; sourceTree = "<group>"; };
+		E264FBD823190992008E0DB5 /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/four.strings; sourceTree = "<group>"; };
+		E264FBDA231909D3008E0DB5 /* ca */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ca; path = ca.lproj/four.strings; sourceTree = "<group>"; };
+		E264FBDC231909F6008E0DB5 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/five.strings; sourceTree = "<group>"; };
+		E264FBDE231909FD008E0DB5 /* fr-CA */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "fr-CA"; path = "fr-CA.lproj/five.strings"; sourceTree = "<group>"; };
+		E264FBDF231909FF008E0DB5 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/five.strings; sourceTree = "<group>"; };
+		E264FBE123190A19008E0DB5 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/six.strings; sourceTree = "<group>"; };
+		E264FBE323190A1F008E0DB5 /* fr-CA */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "fr-CA"; path = "fr-CA.lproj/six.strings"; sourceTree = "<group>"; };
+		E264FBE523190A2F008E0DB5 /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/seven.strings; sourceTree = "<group>"; };
+		E264FBE723190A38008E0DB5 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/seven.strings; sourceTree = "<group>"; };
+		E264FBE823190A3C008E0DB5 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/seven.strings; sourceTree = "<group>"; };
+		E264FBEA23190A49008E0DB5 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/eight.strings; sourceTree = "<group>"; };
+		E264FBEC23190A5A008E0DB5 /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = Base; path = Base.lproj/eight.strings; sourceTree = "<group>"; };
+		E264FBED23190A65008E0DB5 /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/eight.strings; sourceTree = "<group>"; };
+		E264FBEF23190BD4008E0DB5 /* R.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = R.generated.swift; sourceTree = "<group>"; };
+		E264FBF1231A6984008E0DB5 /* en-GB */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "en-GB"; path = "en-GB.lproj/five.strings"; sourceTree = "<group>"; };
+		E264FBF5231A7335008E0DB5 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/nine.strings; sourceTree = "<group>"; };
+		E264FBF7231A7371008E0DB5 /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = Base; path = Base.lproj/nine.strings; sourceTree = "<group>"; };
+		E264FBF8231A7392008E0DB5 /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/nine.strings; sourceTree = "<group>"; };
+		E264FBF9231A73BA008E0DB5 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/nine.strings; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		E264FB9A2319055A008E0DB5 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4BBE4418B51EC4EA7E8ED322 /* libPods-LocalizedStringApp.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E264FBB02319055D008E0DB5 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				76F4720C6B697E9677FA72D7 /* libPods-LocalizedStringAppTests.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		2B4C6133AC39DF6B72B0EE6E /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				9E8A7683B1C7BA67F4482933 /* libPods-LocalizedStringApp.a */,
+				B0E837DDBD8F520F45BD3C01 /* libPods-LocalizedStringAppTests.a */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		5E55C1A9CC154E8588A1B6F3 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				1D03B0D9A8F18724B68DD0FB /* Pods-LocalizedStringApp.debug.xcconfig */,
+				C6B891777D84DD950FA5FFB4 /* Pods-LocalizedStringApp.release.xcconfig */,
+				388F2C098F37BE577962EE06 /* Pods-LocalizedStringAppTests.debug.xcconfig */,
+				2B3837A07F59517ABA7B025C /* Pods-LocalizedStringAppTests.release.xcconfig */,
+			);
+			path = Pods;
+			sourceTree = "<group>";
+		};
+		E264FB942319055A008E0DB5 = {
+			isa = PBXGroup;
+			children = (
+				E264FBEF23190BD4008E0DB5 /* R.generated.swift */,
+				E264FB9F2319055A008E0DB5 /* LocalizedStringApp */,
+				E264FBB62319055D008E0DB5 /* LocalizedStringAppTests */,
+				E264FB9E2319055A008E0DB5 /* Products */,
+				5E55C1A9CC154E8588A1B6F3 /* Pods */,
+				2B4C6133AC39DF6B72B0EE6E /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		E264FB9E2319055A008E0DB5 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				E264FB9D2319055A008E0DB5 /* LocalizedStringApp.app */,
+				E264FBB32319055D008E0DB5 /* LocalizedStringAppTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		E264FB9F2319055A008E0DB5 /* LocalizedStringApp */ = {
+			isa = PBXGroup;
+			children = (
+				E264FBA02319055A008E0DB5 /* AppDelegate.swift */,
+				E264FBAE2319055D008E0DB5 /* Info.plist */,
+				E264FBCE2319082E008E0DB5 /* one.strings */,
+				E264FBD02319083B008E0DB5 /* two.strings */,
+				E264FBD323190962008E0DB5 /* three.strings */,
+				E264FBD723190992008E0DB5 /* four.strings */,
+				E264FBDB231909F6008E0DB5 /* five.strings */,
+				E264FBE023190A19008E0DB5 /* six.strings */,
+				E264FBE423190A2F008E0DB5 /* seven.strings */,
+				E264FBE923190A49008E0DB5 /* eight.strings */,
+				E264FBF6231A7335008E0DB5 /* nine.strings */,
+			);
+			path = LocalizedStringApp;
+			sourceTree = "<group>";
+		};
+		E264FBB62319055D008E0DB5 /* LocalizedStringAppTests */ = {
+			isa = PBXGroup;
+			children = (
+				E264FBB72319055D008E0DB5 /* LocalizedStringAppTests.swift */,
+				E264FBB92319055D008E0DB5 /* Info.plist */,
+			);
+			path = LocalizedStringAppTests;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		E264FB9C2319055A008E0DB5 /* LocalizedStringApp */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E264FBBC2319055D008E0DB5 /* Build configuration list for PBXNativeTarget "LocalizedStringApp" */;
+			buildPhases = (
+				39DE3C8105AEB010961037E4 /* [CP] Check Pods Manifest.lock */,
+				E264FBEE23190B03008E0DB5 /* R.swift */,
+				E264FB992319055A008E0DB5 /* Sources */,
+				E264FB9A2319055A008E0DB5 /* Frameworks */,
+				E264FB9B2319055A008E0DB5 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = LocalizedStringApp;
+			productName = LocalizedStringApp;
+			productReference = E264FB9D2319055A008E0DB5 /* LocalizedStringApp.app */;
+			productType = "com.apple.product-type.application";
+		};
+		E264FBB22319055D008E0DB5 /* LocalizedStringAppTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E264FBBF2319055D008E0DB5 /* Build configuration list for PBXNativeTarget "LocalizedStringAppTests" */;
+			buildPhases = (
+				00D3DD3BE0DE0677D3835C0F /* [CP] Check Pods Manifest.lock */,
+				E264FBAF2319055D008E0DB5 /* Sources */,
+				E264FBB02319055D008E0DB5 /* Frameworks */,
+				E264FBB12319055D008E0DB5 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				E264FBB52319055D008E0DB5 /* PBXTargetDependency */,
+			);
+			name = LocalizedStringAppTests;
+			productName = LocalizedStringAppTests;
+			productReference = E264FBB32319055D008E0DB5 /* LocalizedStringAppTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		E264FB952319055A008E0DB5 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 1100;
+				LastUpgradeCheck = 1100;
+				ORGANIZATIONNAME = R.swift;
+				TargetAttributes = {
+					E264FB9C2319055A008E0DB5 = {
+						CreatedOnToolsVersion = 11.0;
+					};
+					E264FBB22319055D008E0DB5 = {
+						CreatedOnToolsVersion = 11.0;
+						TestTargetID = E264FB9C2319055A008E0DB5;
+					};
+				};
+			};
+			buildConfigurationList = E264FB982319055A008E0DB5 /* Build configuration list for PBXProject "LocalizedStringApp" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = fr;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				ca,
+				en,
+				nl,
+				fr,
+				"fr-CA",
+				Base,
+				"en-GB",
+			);
+			mainGroup = E264FB942319055A008E0DB5;
+			productRefGroup = E264FB9E2319055A008E0DB5 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				E264FB9C2319055A008E0DB5 /* LocalizedStringApp */,
+				E264FBB22319055D008E0DB5 /* LocalizedStringAppTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		E264FB9B2319055A008E0DB5 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E264FBD923190992008E0DB5 /* four.strings in Resources */,
+				E264FBE223190A19008E0DB5 /* six.strings in Resources */,
+				E264FBF4231A7335008E0DB5 /* nine.strings in Resources */,
+				E264FBCF2319082F008E0DB5 /* one.strings in Resources */,
+				E264FBD22319083B008E0DB5 /* two.strings in Resources */,
+				E264FBDD231909F6008E0DB5 /* five.strings in Resources */,
+				E264FBE623190A2F008E0DB5 /* seven.strings in Resources */,
+				E264FBEB23190A49008E0DB5 /* eight.strings in Resources */,
+				E264FBD523190962008E0DB5 /* three.strings in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E264FBB12319055D008E0DB5 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		00D3DD3BE0DE0677D3835C0F /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-LocalizedStringAppTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		39DE3C8105AEB010961037E4 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-LocalizedStringApp-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		E264FBEE23190B03008E0DB5 /* R.swift */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"$(TEMP_DIR)/rswift-lastrun",
+			);
+			name = R.swift;
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				$SRCROOT/R.generated.swift,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"$SRCROOT/../build/Debug/rswift\" generate \"$SRCROOT/R.generated.swift\"\n";
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		E264FB992319055A008E0DB5 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E264FBA12319055A008E0DB5 /* AppDelegate.swift in Sources */,
+				E264FBF023190BD4008E0DB5 /* R.generated.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E264FBAF2319055D008E0DB5 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E264FBB82319055D008E0DB5 /* LocalizedStringAppTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		E264FBB52319055D008E0DB5 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = E264FB9C2319055A008E0DB5 /* LocalizedStringApp */;
+			targetProxy = E264FBB42319055D008E0DB5 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		E264FBD02319083B008E0DB5 /* two.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				E264FBD12319083B008E0DB5 /* en */,
+			);
+			name = two.strings;
+			sourceTree = "<group>";
+		};
+		E264FBD323190962008E0DB5 /* three.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				E264FBD423190962008E0DB5 /* en */,
+				E264FBD62319096F008E0DB5 /* nl */,
+			);
+			name = three.strings;
+			sourceTree = "<group>";
+		};
+		E264FBD723190992008E0DB5 /* four.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				E264FBD823190992008E0DB5 /* nl */,
+				E264FBDA231909D3008E0DB5 /* ca */,
+			);
+			name = four.strings;
+			sourceTree = "<group>";
+		};
+		E264FBDB231909F6008E0DB5 /* five.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				E264FBDC231909F6008E0DB5 /* fr */,
+				E264FBDE231909FD008E0DB5 /* fr-CA */,
+				E264FBDF231909FF008E0DB5 /* en */,
+				E264FBF1231A6984008E0DB5 /* en-GB */,
+			);
+			name = five.strings;
+			sourceTree = "<group>";
+		};
+		E264FBE023190A19008E0DB5 /* six.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				E264FBE123190A19008E0DB5 /* fr */,
+				E264FBE323190A1F008E0DB5 /* fr-CA */,
+			);
+			name = six.strings;
+			sourceTree = "<group>";
+		};
+		E264FBE423190A2F008E0DB5 /* seven.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				E264FBE523190A2F008E0DB5 /* nl */,
+				E264FBE723190A38008E0DB5 /* en */,
+				E264FBE823190A3C008E0DB5 /* fr */,
+			);
+			name = seven.strings;
+			sourceTree = "<group>";
+		};
+		E264FBE923190A49008E0DB5 /* eight.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				E264FBEA23190A49008E0DB5 /* fr */,
+				E264FBEC23190A5A008E0DB5 /* Base */,
+				E264FBED23190A65008E0DB5 /* nl */,
+			);
+			name = eight.strings;
+			sourceTree = "<group>";
+		};
+		E264FBF6231A7335008E0DB5 /* nine.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				E264FBF5231A7335008E0DB5 /* fr */,
+				E264FBF7231A7371008E0DB5 /* Base */,
+				E264FBF8231A7392008E0DB5 /* nl */,
+				E264FBF9231A73BA008E0DB5 /* en */,
+			);
+			name = nine.strings;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		E264FBBA2319055D008E0DB5 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		E264FBBB2319055D008E0DB5 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		E264FBBD2319055D008E0DB5 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 1D03B0D9A8F18724B68DD0FB /* Pods-LocalizedStringApp.debug.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = LC3Y92HQQ3;
+				INFOPLIST_FILE = LocalizedStringApp/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = nl.mathijskadijk.LocalizedStringApp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		E264FBBE2319055D008E0DB5 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = C6B891777D84DD950FA5FFB4 /* Pods-LocalizedStringApp.release.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = LC3Y92HQQ3;
+				INFOPLIST_FILE = LocalizedStringApp/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = nl.mathijskadijk.LocalizedStringApp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		E264FBC02319055D008E0DB5 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 388F2C098F37BE577962EE06 /* Pods-LocalizedStringAppTests.debug.xcconfig */;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = LocalizedStringAppTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = nl.mathijskadijk.LocalizedStringAppTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/LocalizedStringApp.app/LocalizedStringApp";
+			};
+			name = Debug;
+		};
+		E264FBC12319055D008E0DB5 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 2B3837A07F59517ABA7B025C /* Pods-LocalizedStringAppTests.release.xcconfig */;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = LocalizedStringAppTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = nl.mathijskadijk.LocalizedStringAppTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/LocalizedStringApp.app/LocalizedStringApp";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		E264FB982319055A008E0DB5 /* Build configuration list for PBXProject "LocalizedStringApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E264FBBA2319055D008E0DB5 /* Debug */,
+				E264FBBB2319055D008E0DB5 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E264FBBC2319055D008E0DB5 /* Build configuration list for PBXNativeTarget "LocalizedStringApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E264FBBD2319055D008E0DB5 /* Debug */,
+				E264FBBE2319055D008E0DB5 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E264FBBF2319055D008E0DB5 /* Build configuration list for PBXNativeTarget "LocalizedStringAppTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E264FBC02319055D008E0DB5 /* Debug */,
+				E264FBC12319055D008E0DB5 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = E264FB952319055A008E0DB5 /* Project object */;
+}

--- a/LocalizedStringApp/LocalizedStringApp.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/LocalizedStringApp/LocalizedStringApp.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:LocalizedStringApp.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/LocalizedStringApp/LocalizedStringApp.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/LocalizedStringApp/LocalizedStringApp.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/LocalizedStringApp/LocalizedStringApp.xcodeproj/xcshareddata/xcschemes/LocalizedStringApp Dutch.xcscheme
+++ b/LocalizedStringApp/LocalizedStringApp.xcodeproj/xcshareddata/xcschemes/LocalizedStringApp Dutch.xcscheme
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1100"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E264FB9C2319055A008E0DB5"
+               BuildableName = "LocalizedStringApp.app"
+               BlueprintName = "LocalizedStringApp"
+               ReferencedContainer = "container:LocalizedStringApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E264FBB22319055D008E0DB5"
+               BuildableName = "LocalizedStringAppTests.xctest"
+               BlueprintName = "LocalizedStringAppTests"
+               ReferencedContainer = "container:LocalizedStringApp.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = "nl"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E264FB9C2319055A008E0DB5"
+            BuildableName = "LocalizedStringApp.app"
+            BlueprintName = "LocalizedStringApp"
+            ReferencedContainer = "container:LocalizedStringApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E264FB9C2319055A008E0DB5"
+            BuildableName = "LocalizedStringApp.app"
+            BlueprintName = "LocalizedStringApp"
+            ReferencedContainer = "container:LocalizedStringApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/LocalizedStringApp/LocalizedStringApp.xcodeproj/xcshareddata/xcschemes/LocalizedStringApp English.xcscheme
+++ b/LocalizedStringApp/LocalizedStringApp.xcodeproj/xcshareddata/xcschemes/LocalizedStringApp English.xcscheme
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1100"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E264FB9C2319055A008E0DB5"
+               BuildableName = "LocalizedStringApp.app"
+               BlueprintName = "LocalizedStringApp"
+               ReferencedContainer = "container:LocalizedStringApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E264FBB22319055D008E0DB5"
+               BuildableName = "LocalizedStringAppTests.xctest"
+               BlueprintName = "LocalizedStringAppTests"
+               ReferencedContainer = "container:LocalizedStringApp.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = "en"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E264FB9C2319055A008E0DB5"
+            BuildableName = "LocalizedStringApp.app"
+            BlueprintName = "LocalizedStringApp"
+            ReferencedContainer = "container:LocalizedStringApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E264FB9C2319055A008E0DB5"
+            BuildableName = "LocalizedStringApp.app"
+            BlueprintName = "LocalizedStringApp"
+            ReferencedContainer = "container:LocalizedStringApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/LocalizedStringApp/LocalizedStringApp.xcodeproj/xcshareddata/xcschemes/LocalizedStringApp French (Canada).xcscheme
+++ b/LocalizedStringApp/LocalizedStringApp.xcodeproj/xcshareddata/xcschemes/LocalizedStringApp French (Canada).xcscheme
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1100"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E264FB9C2319055A008E0DB5"
+               BuildableName = "LocalizedStringApp.app"
+               BlueprintName = "LocalizedStringApp"
+               ReferencedContainer = "container:LocalizedStringApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E264FBB22319055D008E0DB5"
+               BuildableName = "LocalizedStringAppTests.xctest"
+               BlueprintName = "LocalizedStringAppTests"
+               ReferencedContainer = "container:LocalizedStringApp.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = "fr-CA"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E264FB9C2319055A008E0DB5"
+            BuildableName = "LocalizedStringApp.app"
+            BlueprintName = "LocalizedStringApp"
+            ReferencedContainer = "container:LocalizedStringApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E264FB9C2319055A008E0DB5"
+            BuildableName = "LocalizedStringApp.app"
+            BlueprintName = "LocalizedStringApp"
+            ReferencedContainer = "container:LocalizedStringApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/LocalizedStringApp/LocalizedStringApp.xcodeproj/xcshareddata/xcschemes/LocalizedStringApp French.xcscheme
+++ b/LocalizedStringApp/LocalizedStringApp.xcodeproj/xcshareddata/xcschemes/LocalizedStringApp French.xcscheme
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1100"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E264FB9C2319055A008E0DB5"
+               BuildableName = "LocalizedStringApp.app"
+               BlueprintName = "LocalizedStringApp"
+               ReferencedContainer = "container:LocalizedStringApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E264FBB22319055D008E0DB5"
+               BuildableName = "LocalizedStringAppTests.xctest"
+               BlueprintName = "LocalizedStringAppTests"
+               ReferencedContainer = "container:LocalizedStringApp.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = "fr"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E264FB9C2319055A008E0DB5"
+            BuildableName = "LocalizedStringApp.app"
+            BlueprintName = "LocalizedStringApp"
+            ReferencedContainer = "container:LocalizedStringApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E264FB9C2319055A008E0DB5"
+            BuildableName = "LocalizedStringApp.app"
+            BlueprintName = "LocalizedStringApp"
+            ReferencedContainer = "container:LocalizedStringApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/LocalizedStringApp/LocalizedStringApp.xcodeproj/xcshareddata/xcschemes/LocalizedStringApp Turkish.xcscheme
+++ b/LocalizedStringApp/LocalizedStringApp.xcodeproj/xcshareddata/xcschemes/LocalizedStringApp Turkish.xcscheme
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1100"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E264FB9C2319055A008E0DB5"
+               BuildableName = "LocalizedStringApp.app"
+               BlueprintName = "LocalizedStringApp"
+               ReferencedContainer = "container:LocalizedStringApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E264FBB22319055D008E0DB5"
+               BuildableName = "LocalizedStringAppTests.xctest"
+               BlueprintName = "LocalizedStringAppTests"
+               ReferencedContainer = "container:LocalizedStringApp.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = "tr"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E264FB9C2319055A008E0DB5"
+            BuildableName = "LocalizedStringApp.app"
+            BlueprintName = "LocalizedStringApp"
+            ReferencedContainer = "container:LocalizedStringApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E264FB9C2319055A008E0DB5"
+            BuildableName = "LocalizedStringApp.app"
+            BlueprintName = "LocalizedStringApp"
+            ReferencedContainer = "container:LocalizedStringApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/LocalizedStringApp/LocalizedStringApp.xcodeproj/xcshareddata/xcschemes/LocalizedStringApp.xcscheme
+++ b/LocalizedStringApp/LocalizedStringApp.xcodeproj/xcshareddata/xcschemes/LocalizedStringApp.xcscheme
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1100"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E264FB9C2319055A008E0DB5"
+               BuildableName = "LocalizedStringApp.app"
+               BlueprintName = "LocalizedStringApp"
+               ReferencedContainer = "container:LocalizedStringApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E264FBB22319055D008E0DB5"
+               BuildableName = "LocalizedStringAppTests.xctest"
+               BlueprintName = "LocalizedStringAppTests"
+               ReferencedContainer = "container:LocalizedStringApp.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E264FB9C2319055A008E0DB5"
+            BuildableName = "LocalizedStringApp.app"
+            BlueprintName = "LocalizedStringApp"
+            ReferencedContainer = "container:LocalizedStringApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E264FB9C2319055A008E0DB5"
+            BuildableName = "LocalizedStringApp.app"
+            BlueprintName = "LocalizedStringApp"
+            ReferencedContainer = "container:LocalizedStringApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/LocalizedStringApp/LocalizedStringApp.xcworkspace/contents.xcworkspacedata
+++ b/LocalizedStringApp/LocalizedStringApp.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:LocalizedStringApp.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/LocalizedStringApp/LocalizedStringApp.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/LocalizedStringApp/LocalizedStringApp.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/LocalizedStringApp/LocalizedStringApp/AppDelegate.swift
+++ b/LocalizedStringApp/LocalizedStringApp/AppDelegate.swift
@@ -1,0 +1,135 @@
+//
+//  AppDelegate.swift
+//  LocalizedStringApp
+//
+//  Created by Tom Lokhorst on 2019-08-30.
+//  Copyright © 2019 R.swift. All rights reserved.
+//
+
+import UIKit
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+
+
+  func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+
+    let myprefs: [String] = ["fr-CA"]
+
+    print("Locale.preferredLanguages:")
+    print(Locale.preferredLanguages)
+    print()
+    print("Bundle.main.preferredLocalizations:")
+    print(Bundle.main.preferredLocalizations)
+    print()
+    print("Test:")
+    print(NSLocalizedString("one1", tableName: "one", comment: ""))
+    print(R.string.one.one1())
+    print(R.string.one.one1(preferredLanguages: myprefs))
+    print()
+    print(NSLocalizedString("one2", tableName: "one", comment: ""))
+    print(R.string.one.one2())
+    print(R.string.one.one2(preferredLanguages: myprefs))
+    print()
+
+    print(NSLocalizedString("two1", tableName: "two", comment: ""))
+    print(R.string.two.two1())
+    print(R.string.two.two1(preferredLanguages: myprefs))
+    print()
+    print(String(format: NSLocalizedString("two2", tableName: "two", comment: ""), locale: Locale(identifier: myprefs.first!), "Hello"))
+    print(R.string.two.two2("Hello"))
+    print(R.string.two.two2("Hello", preferredLanguages: myprefs))
+    print()
+
+    print(NSLocalizedString("three1", tableName: "three", comment: ""))
+    print(R.string.three.three1())
+    print(R.string.three.three1(preferredLanguages: myprefs))
+    print()
+    print(NSLocalizedString("three2", tableName: "three", comment: ""))
+    print(R.string.three.three2())
+    print(R.string.three.three2(preferredLanguages: myprefs))
+    print()
+    print(NSLocalizedString("three3", tableName: "three", comment: ""))
+    print(R.string.three.three3())
+    print(R.string.three.three3(preferredLanguages: myprefs))
+    print()
+
+    print(NSLocalizedString("four1", tableName: "four", comment: ""))
+    print(R.string.four.four1())
+    print(R.string.four.four1(preferredLanguages: myprefs))
+    print()
+
+    print(NSLocalizedString("five1", tableName: "five", comment: ""))
+    print(R.string.five.five1())
+    print(R.string.five.five1(preferredLanguages: myprefs))
+    print()
+    print(NSLocalizedString("five2", tableName: "five", comment: ""))
+    print(R.string.five.five2())
+    print(R.string.five.five2(preferredLanguages: myprefs))
+    print()
+    print(NSLocalizedString("five4", tableName: "five", comment: ""))
+    print(R.string.five.five4())
+    print(R.string.five.five4(preferredLanguages: myprefs))
+    print()
+
+    print(NSLocalizedString("six1", tableName: "six", comment: ""))
+    print(R.string.six.six1())
+    print(R.string.six.six1(preferredLanguages: myprefs))
+    print()
+    print(NSLocalizedString("six2", tableName: "six", comment: ""))
+    print(R.string.six.six2())
+    print(R.string.six.six2(preferredLanguages: myprefs))
+    print()
+
+    print(NSLocalizedString("seven1", tableName: "seven", comment: ""))
+    print(R.string.seven.seven1())
+    print(R.string.seven.seven1(preferredLanguages: myprefs))
+    print()
+    print(NSLocalizedString("seven2", tableName: "seven", comment: ""))
+    print(R.string.seven.seven2())
+    print(R.string.seven.seven2(preferredLanguages: myprefs))
+    print()
+    print(NSLocalizedString("seven3", tableName: "seven", comment: ""))
+    print(R.string.seven.seven3())
+    print(R.string.seven.seven3(preferredLanguages: myprefs))
+    print()
+    print(NSLocalizedString("seven4", tableName: "seven", comment: ""))
+    print(R.string.seven.seven4())
+    print(R.string.seven.seven4(preferredLanguages: myprefs))
+    print()
+
+    print(NSLocalizedString("eight1", tableName: "eight", comment: ""))
+    print(R.string.eight.eight1())
+    print(R.string.eight.eight1(preferredLanguages: myprefs))
+    print()
+    print(NSLocalizedString("eight2", tableName: "eight", comment: ""))
+    print(R.string.eight.eight2())
+    print(R.string.eight.eight2(preferredLanguages: myprefs))
+    print()
+    print(NSLocalizedString("eight3", tableName: "eight", comment: ""))
+    print(R.string.eight.eight3())
+    print(R.string.eight.eight3(preferredLanguages: myprefs))
+    print()
+
+    print(NSLocalizedString("nine1", tableName: "nine", comment: ""))
+    print(R.string.nine.nine1())
+    print(R.string.nine.nine1(preferredLanguages: myprefs))
+    print()
+    print(NSLocalizedString("nine2", tableName: "nine", comment: ""))
+    print(R.string.nine.nine2())
+    print(R.string.nine.nine2(preferredLanguages: myprefs))
+    print()
+    print(NSLocalizedString("nine", tableName: "nine", comment: ""))
+    print(R.string.nine.nine3())
+    print(R.string.nine.nine3(preferredLanguages: myprefs))
+    print()
+
+
+
+    return true
+  }
+
+
+}
+

--- a/LocalizedStringApp/LocalizedStringApp/Base.lproj/eight.strings
+++ b/LocalizedStringApp/LocalizedStringApp/Base.lproj/eight.strings
@@ -1,0 +1,11 @@
+/* 
+  eight.strings
+  LocalizedStringApp
+
+  Created by Tom Lokhorst on 2019-08-26.
+  Copyright © 2019 R.swift. All rights reserved.
+*/
+
+"eight1" = "eight 1, localized base";
+"eight2" = "eight 2, localized base";
+"eight3" = "eight 3, localized base";

--- a/LocalizedStringApp/LocalizedStringApp/Base.lproj/nine.strings
+++ b/LocalizedStringApp/LocalizedStringApp/Base.lproj/nine.strings
@@ -1,0 +1,11 @@
+/* 
+  nine.strings
+  LocalizedStringApp
+
+  Created by Tom Lokhorst on 2019-08-31.
+  Copyright © 2019 R.swift. All rights reserved.
+*/
+
+"nine1" = "nine 1, localized base";
+"nine2" = "nine 2, localized base";
+"nine3" = "nine 3, localized base";

--- a/LocalizedStringApp/LocalizedStringApp/Info.plist
+++ b/LocalizedStringApp/LocalizedStringApp/Info.plist
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSApplicationCategoryType</key>
+	<string></string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/LocalizedStringApp/LocalizedStringApp/ca.lproj/four.strings
+++ b/LocalizedStringApp/LocalizedStringApp/ca.lproj/four.strings
@@ -1,0 +1,9 @@
+/* 
+  four.strings
+  LocalizedStringApp
+
+  Created by Tom Lokhorst on 2019-08-21.
+  Copyright © 2019 R.swift. All rights reserved.
+*/
+
+"four1" = "four 1, localized catalan";

--- a/LocalizedStringApp/LocalizedStringApp/en-GB.lproj/five.strings
+++ b/LocalizedStringApp/LocalizedStringApp/en-GB.lproj/five.strings
@@ -1,0 +1,9 @@
+/* 
+  five.strings
+  LocalizedStringApp
+
+  Created by Tom Lokhorst on 2019-08-21.
+  Copyright © 2019 R.swift. All rights reserved.
+*/
+
+"five1" = "five 1, localized english gb";

--- a/LocalizedStringApp/LocalizedStringApp/en.lproj/MyStoryboard.storyboard
+++ b/LocalizedStringApp/LocalizedStringApp/en.lproj/MyStoryboard.storyboard
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14865.1" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="cI2-jD-mV4">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14819.2"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="DOG-Xu-M6F">
+            <objects>
+                <viewController storyboardIdentifier="First" useStoryboardIdentifierAsRestorationIdentifier="YES" id="cI2-jD-mV4" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="6oG-iq-Lyu">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="Tdr-ao-2GW"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dXj-TI-GFt" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="342" y="56"/>
+        </scene>
+    </scenes>
+</document>

--- a/LocalizedStringApp/LocalizedStringApp/en.lproj/five.strings
+++ b/LocalizedStringApp/LocalizedStringApp/en.lproj/five.strings
@@ -1,0 +1,11 @@
+/* 
+  five.strings
+  LocalizedStringApp
+
+  Created by Tom Lokhorst on 2019-08-21.
+  Copyright © 2019 R.swift. All rights reserved.
+*/
+
+"five1" = "five 1, localized english";
+"five2" = "five 2, localized english";
+"five3" = "five 3, localized english";

--- a/LocalizedStringApp/LocalizedStringApp/en.lproj/nine.strings
+++ b/LocalizedStringApp/LocalizedStringApp/en.lproj/nine.strings
@@ -1,0 +1,10 @@
+/* 
+  nine.strings
+  LocalizedStringApp
+
+  Created by Tom Lokhorst on 2019-08-31.
+  Copyright © 2019 R.swift. All rights reserved.
+*/
+
+"nine1" = "nine 1, localized english";
+"nine2" = "nine 2, localized english";

--- a/LocalizedStringApp/LocalizedStringApp/en.lproj/seven.strings
+++ b/LocalizedStringApp/LocalizedStringApp/en.lproj/seven.strings
@@ -1,0 +1,10 @@
+/* 
+  seven.strings
+  LocalizedStringApp
+
+  Created by Tom Lokhorst on 2019-08-22.
+  Copyright © 2019 R.swift. All rights reserved.
+*/
+
+"seven1" = "seven 1, localized english";
+"seven2" = "seven 2, localized english";

--- a/LocalizedStringApp/LocalizedStringApp/en.lproj/three.strings
+++ b/LocalizedStringApp/LocalizedStringApp/en.lproj/three.strings
@@ -1,0 +1,10 @@
+/* 
+  three.strings
+  LocalizedStringApp
+
+  Created by Tom Lokhorst on 2019-08-21.
+  Copyright © 2019 R.swift. All rights reserved.
+*/
+
+"three1" = "three 1, localized english";
+"three2" = "three 2, localized english";

--- a/LocalizedStringApp/LocalizedStringApp/en.lproj/two.strings
+++ b/LocalizedStringApp/LocalizedStringApp/en.lproj/two.strings
@@ -1,0 +1,10 @@
+/* 
+  two.strings
+  LocalizedStringApp
+
+  Created by Tom Lokhorst on 2019-08-21.
+  Copyright © 2019 R.swift. All rights reserved.
+*/
+
+"two1" = "two 1, localized english";
+"two2" = "two 2, %@ localized english";

--- a/LocalizedStringApp/LocalizedStringApp/fr-CA.lproj/five.strings
+++ b/LocalizedStringApp/LocalizedStringApp/fr-CA.lproj/five.strings
@@ -1,0 +1,9 @@
+/* 
+  five.strings
+  LocalizedStringApp
+
+  Created by Tom Lokhorst on 2019-08-21.
+  Copyright © 2019 R.swift. All rights reserved.
+*/
+
+"five1" = "five 1, localized french canada";

--- a/LocalizedStringApp/LocalizedStringApp/fr-CA.lproj/six.strings
+++ b/LocalizedStringApp/LocalizedStringApp/fr-CA.lproj/six.strings
@@ -1,0 +1,9 @@
+/* 
+  six.strings
+  LocalizedStringApp
+
+  Created by Tom Lokhorst on 2019-08-21.
+  Copyright © 2019 R.swift. All rights reserved.
+*/
+
+"six1" = "six 1, localized french canada";

--- a/LocalizedStringApp/LocalizedStringApp/fr.lproj/eight.strings
+++ b/LocalizedStringApp/LocalizedStringApp/fr.lproj/eight.strings
@@ -1,0 +1,10 @@
+/* 
+  eight.strings
+  LocalizedStringApp
+
+  Created by Tom Lokhorst on 2019-08-26.
+  Copyright © 2019 R.swift. All rights reserved.
+*/
+
+"eight1" = "eight 1, localized french";
+"eight2" = "eight 2, localized french";

--- a/LocalizedStringApp/LocalizedStringApp/fr.lproj/five.strings
+++ b/LocalizedStringApp/LocalizedStringApp/fr.lproj/five.strings
@@ -1,0 +1,12 @@
+/* 
+  five.strings
+  LocalizedStringApp
+
+  Created by Tom Lokhorst on 2019-08-21.
+  Copyright © 2019 R.swift. All rights reserved.
+*/
+
+"five1" = "five 1, localized french";
+"five2" = "five 2, localized french";
+
+"five4" = "five 4, localized french";

--- a/LocalizedStringApp/LocalizedStringApp/fr.lproj/nine.strings
+++ b/LocalizedStringApp/LocalizedStringApp/fr.lproj/nine.strings
@@ -1,0 +1,10 @@
+/* 
+  nine.strings
+  LocalizedStringApp
+
+  Created by Tom Lokhorst on 2019-08-31.
+  Copyright © 2019 R.swift. All rights reserved.
+*/
+
+"nine1" = "nine 1, localized french";
+"nine2" = "nine 2, localized french";

--- a/LocalizedStringApp/LocalizedStringApp/fr.lproj/seven.strings
+++ b/LocalizedStringApp/LocalizedStringApp/fr.lproj/seven.strings
@@ -1,0 +1,12 @@
+/* 
+  seven.strings
+  LocalizedStringApp
+
+  Created by Tom Lokhorst on 2019-08-22.
+  Copyright © 2019 R.swift. All rights reserved.
+*/
+
+"seven1" = "seven 1, localized french";
+"seven2" = "seven 2, localized french";
+"seven3" = "seven 3, localized french";
+"seven4" = "seven 4, localized french";

--- a/LocalizedStringApp/LocalizedStringApp/fr.lproj/six.strings
+++ b/LocalizedStringApp/LocalizedStringApp/fr.lproj/six.strings
@@ -1,0 +1,10 @@
+/* 
+  six.strings
+  LocalizedStringApp
+
+  Created by Tom Lokhorst on 2019-08-21.
+  Copyright © 2019 R.swift. All rights reserved.
+*/
+
+"six1" = "six 1, localized french";
+"six2" = "six 2, localized french";

--- a/LocalizedStringApp/LocalizedStringApp/nl.lproj/eight.strings
+++ b/LocalizedStringApp/LocalizedStringApp/nl.lproj/eight.strings
@@ -1,0 +1,12 @@
+/* 
+  eight.strings
+  LocalizedStringApp
+
+  Created by Tom Lokhorst on 2019-08-26.
+  Copyright © 2019 R.swift. All rights reserved.
+*/
+
+"eight1" = "eight 1, localized dutch";
+
+
+"eight4" = "eight 4, localized dutch";

--- a/LocalizedStringApp/LocalizedStringApp/nl.lproj/four.strings
+++ b/LocalizedStringApp/LocalizedStringApp/nl.lproj/four.strings
@@ -1,0 +1,9 @@
+/* 
+  four.strings
+  LocalizedStringApp
+
+  Created by Tom Lokhorst on 2019-08-21.
+  Copyright © 2019 R.swift. All rights reserved.
+*/
+
+"four1" = "four 1, localized dutch";

--- a/LocalizedStringApp/LocalizedStringApp/nl.lproj/nine.strings
+++ b/LocalizedStringApp/LocalizedStringApp/nl.lproj/nine.strings
@@ -1,0 +1,12 @@
+/* 
+  nine.strings
+  LocalizedStringApp
+
+  Created by Tom Lokhorst on 2019-08-31.
+  Copyright © 2019 R.swift. All rights reserved.
+*/
+
+"nine1" = "nine 1, localized dutch";
+
+
+"nine4" = "nine 4, localized dutch";

--- a/LocalizedStringApp/LocalizedStringApp/nl.lproj/seven.strings
+++ b/LocalizedStringApp/LocalizedStringApp/nl.lproj/seven.strings
@@ -1,0 +1,12 @@
+/* 
+  seven.strings
+  LocalizedStringApp
+
+  Created by Tom Lokhorst on 2019-08-22.
+  Copyright © 2019 R.swift. All rights reserved.
+*/
+
+"seven1" = "seven 1, localized dutch";
+
+
+"seven4" = "seven 4, localized dutch";

--- a/LocalizedStringApp/LocalizedStringApp/nl.lproj/three.strings
+++ b/LocalizedStringApp/LocalizedStringApp/nl.lproj/three.strings
@@ -1,0 +1,11 @@
+/* 
+  three.strings
+  LocalizedStringApp
+
+  Created by Tom Lokhorst on 2019-08-21.
+  Copyright © 2019 R.swift. All rights reserved.
+*/
+
+"three1" = "three 1, localized dutch";
+
+"three3" = "three 3, localized dutch";

--- a/LocalizedStringApp/LocalizedStringApp/one.strings
+++ b/LocalizedStringApp/LocalizedStringApp/one.strings
@@ -1,0 +1,10 @@
+/* 
+  one.strings
+  LocalizedStringApp
+
+  Created by Tom Lokhorst on 2019-08-21.
+  Copyright © 2019 R.swift. All rights reserved.
+*/
+
+"one1" = "one 1, not localized";
+"one2" = "one 2, not localized";

--- a/LocalizedStringApp/LocalizedStringAppTests/Info.plist
+++ b/LocalizedStringApp/LocalizedStringAppTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/LocalizedStringApp/LocalizedStringAppTests/LocalizedStringAppTests.swift
+++ b/LocalizedStringApp/LocalizedStringAppTests/LocalizedStringAppTests.swift
@@ -1,0 +1,429 @@
+//
+//  LocalizedStringAppTests.swift
+//  LocalizedStringAppTests
+//
+//  Created by Tom Lokhorst on 2019-08-30.
+//  Copyright © 2019 R.swift. All rights reserved.
+//
+
+import XCTest
+@testable import LocalizedStringApp
+
+class LocalizedStringAppTests: XCTestCase {
+
+  func testDefault() {
+    XCTAssertEqual(
+      R.string.one.one1(),
+      NSLocalizedString("one1", tableName: "one", comment: "")
+    )
+    XCTAssertEqual(
+      R.string.one.one2(),
+      NSLocalizedString("one2", tableName: "one", comment: "")
+    )
+
+    XCTAssertEqual(
+      R.string.two.two1(),
+      NSLocalizedString("two1", tableName: "two", comment: "")
+    )
+    XCTAssertEqual(
+      R.string.two.two2("Hello"),
+      String(format: NSLocalizedString("two2", tableName: "two", comment: ""), locale: Locale.current, "Hello")
+    )
+
+    XCTAssertEqual(
+      R.string.three.three1(),
+      NSLocalizedString("three1", tableName: "three", comment: "")
+    )
+    XCTAssertEqual(
+      R.string.three.three2(),
+      NSLocalizedString("three2", tableName: "three", comment: "")
+    )
+    XCTAssertEqual(
+      R.string.three.three2(),
+      NSLocalizedString("three2", tableName: "three", comment: "")
+    )
+
+    XCTAssertEqual(
+      R.string.four.four1(),
+      NSLocalizedString("four1", tableName: "four", comment: "")
+    )
+
+    XCTAssertEqual(
+      R.string.five.five1(),
+      NSLocalizedString("five1", tableName: "five", comment: "")
+    )
+    XCTAssertEqual(
+      R.string.five.five2(),
+      NSLocalizedString("five2", tableName: "five", comment: "")
+    )
+    XCTAssertEqual(
+      R.string.five.five4(),
+      NSLocalizedString("five4", tableName: "five", comment: "")
+    )
+
+    XCTAssertEqual(
+      R.string.six.six1(),
+      NSLocalizedString("six1", tableName: "six", comment: "")
+    )
+    XCTAssertEqual(
+      R.string.six.six2(),
+      NSLocalizedString("six2", tableName: "six", comment: "")
+    )
+
+    XCTAssertEqual(
+      R.string.seven.seven1(),
+      NSLocalizedString("seven1", tableName: "seven", comment: "")
+    )
+    XCTAssertEqual(
+      R.string.seven.seven2(),
+      NSLocalizedString("seven2", tableName: "seven", comment: "")
+    )
+    XCTAssertEqual(
+      R.string.seven.seven3(),
+      NSLocalizedString("seven3", tableName: "seven", comment: "")
+    )
+    XCTAssertEqual(
+      R.string.seven.seven4(),
+      NSLocalizedString("seven4", tableName: "seven", comment: "")
+    )
+
+    XCTAssertEqual(
+      R.string.eight.eight1(),
+      NSLocalizedString("eight1", tableName: "eight", comment: "")
+    )
+    XCTAssertEqual(
+      R.string.eight.eight2(),
+      NSLocalizedString("eight2", tableName: "eight", comment: "")
+    )
+    XCTAssertEqual(
+      R.string.eight.eight3(),
+      NSLocalizedString("eight3", tableName: "eight", comment: "")
+    )
+
+    XCTAssertEqual(
+      R.string.nine.nine1(),
+      NSLocalizedString("nine1", tableName: "nine", comment: "")
+    )
+    XCTAssertEqual(
+      R.string.nine.nine2(),
+      NSLocalizedString("nine2", tableName: "nine", comment: "")
+    )
+//    XCTAssertEqual(
+//      R.string.nine.nine3(),
+//      NSLocalizedString("nine3", tableName: "nine", comment: "")
+//    )
+  }
+
+
+  func testTurkish() {
+    let myprefs = ["tr"]
+
+    XCTAssertEqual(R.string.one.one1(preferredLanguages: myprefs),
+                   "one 1, not localized")
+    XCTAssertEqual(R.string.one.one2(preferredLanguages: myprefs),
+                   "one 2, not localized")
+    XCTAssertEqual(R.string.two.two1(preferredLanguages: myprefs),
+                   "two1")
+    XCTAssertEqual(R.string.two.two2("Hello", preferredLanguages: myprefs),
+                   "two2")
+    XCTAssertEqual(R.string.three.three1(preferredLanguages: myprefs),
+                   "three1")
+    XCTAssertEqual(R.string.three.three2(preferredLanguages: myprefs),
+                   "three2")
+    XCTAssertEqual(R.string.three.three3(preferredLanguages: myprefs),
+                   "three3")
+    XCTAssertEqual(R.string.four.four1(preferredLanguages: myprefs),
+                   "four1")
+    XCTAssertEqual(R.string.five.five1(preferredLanguages: myprefs),
+                   "five 1, localized french")
+    XCTAssertEqual(R.string.five.five2(preferredLanguages: myprefs),
+                   "five 2, localized french")
+    XCTAssertEqual(R.string.five.five4(preferredLanguages: myprefs),
+                   "five 4, localized french")
+    XCTAssertEqual(R.string.six.six1(preferredLanguages: myprefs),
+                   "six 1, localized french")
+    XCTAssertEqual(R.string.six.six2(preferredLanguages: myprefs),
+                   "six 2, localized french")
+    XCTAssertEqual(R.string.seven.seven1(preferredLanguages: myprefs),
+                   "seven 1, localized french")
+    XCTAssertEqual(R.string.seven.seven2(preferredLanguages: myprefs),
+                   "seven 2, localized french")
+    XCTAssertEqual(R.string.seven.seven3(preferredLanguages: myprefs),
+                   "seven 3, localized french")
+    XCTAssertEqual(R.string.seven.seven4(preferredLanguages: myprefs),
+                   "seven 4, localized french")
+    XCTAssertEqual(R.string.eight.eight1(preferredLanguages: myprefs),
+                   "eight 1, localized french")
+    XCTAssertEqual(R.string.eight.eight2(preferredLanguages: myprefs),
+                   "eight 2, localized french")
+    XCTAssertEqual(R.string.eight.eight3(preferredLanguages: myprefs),
+                   "eight 3, localized base")
+    XCTAssertEqual(R.string.nine.nine1(preferredLanguages: myprefs),
+                   "nine 1, localized french")
+    XCTAssertEqual(R.string.nine.nine2(preferredLanguages: myprefs),
+                   "nine 2, localized french")
+    XCTAssertEqual(R.string.nine.nine3(preferredLanguages: myprefs),
+                   "nine 3, localized base")
+  }
+
+
+  func testDutch() {
+    let myprefs = ["nl"]
+
+    XCTAssertEqual(R.string.one.one1(preferredLanguages: myprefs),
+                   "one 1, not localized")
+    XCTAssertEqual(R.string.one.one2(preferredLanguages: myprefs),
+                   "one 2, not localized")
+    XCTAssertEqual(R.string.two.two1(preferredLanguages: myprefs),
+                   "two1")
+    XCTAssertEqual(R.string.two.two2("Hello", preferredLanguages: myprefs),
+                   "two2")
+    XCTAssertEqual(R.string.three.three1(preferredLanguages: myprefs),
+                   "three 1, localized dutch")
+    XCTAssertEqual(R.string.three.three2(preferredLanguages: myprefs),
+                   "three2")
+    XCTAssertEqual(R.string.three.three3(preferredLanguages: myprefs),
+                   "three 3, localized dutch")
+    XCTAssertEqual(R.string.four.four1(preferredLanguages: myprefs),
+                   "four 1, localized dutch")
+    XCTAssertEqual(R.string.five.five1(preferredLanguages: myprefs),
+                   "five 1, localized french")
+    XCTAssertEqual(R.string.five.five2(preferredLanguages: myprefs),
+                   "five 2, localized french")
+    XCTAssertEqual(R.string.five.five4(preferredLanguages: myprefs),
+                   "five 4, localized french")
+    XCTAssertEqual(R.string.six.six1(preferredLanguages: myprefs),
+                   "six 1, localized french")
+    XCTAssertEqual(R.string.six.six2(preferredLanguages: myprefs),
+                   "six 2, localized french")
+    XCTAssertEqual(R.string.seven.seven1(preferredLanguages: myprefs),
+                   "seven 1, localized dutch")
+    XCTAssertEqual(R.string.seven.seven2(preferredLanguages: myprefs),
+                   "seven2")
+    XCTAssertEqual(R.string.seven.seven3(preferredLanguages: myprefs),
+                   "seven3")
+    XCTAssertEqual(R.string.seven.seven4(preferredLanguages: myprefs),
+                   "seven 4, localized dutch")
+    XCTAssertEqual(R.string.eight.eight1(preferredLanguages: myprefs),
+                   "eight 1, localized dutch")
+    XCTAssertEqual(R.string.eight.eight2(preferredLanguages: myprefs),
+                   "eight 2, localized base")
+    XCTAssertEqual(R.string.eight.eight3(preferredLanguages: myprefs),
+                   "eight 3, localized base")
+    XCTAssertEqual(R.string.nine.nine1(preferredLanguages: myprefs),
+                   "nine 1, localized dutch")
+    XCTAssertEqual(R.string.nine.nine2(preferredLanguages: myprefs),
+                   "nine 2, localized base")
+    XCTAssertEqual(R.string.nine.nine3(preferredLanguages: myprefs),
+                   "nine 3, localized base")
+  }
+
+
+  func testEnglish() {
+    let myprefs = ["en"]
+
+    XCTAssertEqual(R.string.one.one1(preferredLanguages: myprefs),
+                   "one 1, not localized")
+    XCTAssertEqual(R.string.one.one2(preferredLanguages: myprefs),
+                   "one 2, not localized")
+    XCTAssertEqual(R.string.two.two1(preferredLanguages: myprefs),
+                   "two 1, localized english")
+    XCTAssertEqual(R.string.two.two2("Hello", preferredLanguages: myprefs),
+                   "two 2, Hello localized english")
+    XCTAssertEqual(R.string.three.three1(preferredLanguages: myprefs),
+                   "three 1, localized english")
+    XCTAssertEqual(R.string.three.three2(preferredLanguages: myprefs),
+                   "three 2, localized english")
+    XCTAssertEqual(R.string.three.three3(preferredLanguages: myprefs),
+                   "three3")
+    XCTAssertEqual(R.string.four.four1(preferredLanguages: myprefs),
+                   "four1")
+    XCTAssertEqual(R.string.five.five1(preferredLanguages: myprefs),
+                   "five 1, localized english")
+    XCTAssertEqual(R.string.five.five2(preferredLanguages: myprefs),
+                   "five 2, localized english")
+    XCTAssertEqual(R.string.five.five4(preferredLanguages: myprefs),
+                   "five4")
+    XCTAssertEqual(R.string.six.six1(preferredLanguages: myprefs),
+                   "six 1, localized french")
+    XCTAssertEqual(R.string.six.six2(preferredLanguages: myprefs),
+                   "six 2, localized french")
+    XCTAssertEqual(R.string.seven.seven1(preferredLanguages: myprefs),
+                   "seven 1, localized english")
+    XCTAssertEqual(R.string.seven.seven2(preferredLanguages: myprefs),
+                   "seven 2, localized english")
+    XCTAssertEqual(R.string.seven.seven3(preferredLanguages: myprefs),
+                   "seven3")
+    XCTAssertEqual(R.string.seven.seven4(preferredLanguages: myprefs),
+                   "seven4")
+    XCTAssertEqual(R.string.eight.eight1(preferredLanguages: myprefs),
+                   "eight 1, localized base")
+    XCTAssertEqual(R.string.eight.eight2(preferredLanguages: myprefs),
+                   "eight 2, localized base")
+    XCTAssertEqual(R.string.eight.eight3(preferredLanguages: myprefs),
+                   "eight 3, localized base")
+    XCTAssertEqual(R.string.nine.nine1(preferredLanguages: myprefs),
+                   "nine 1, localized english")
+    XCTAssertEqual(R.string.nine.nine2(preferredLanguages: myprefs),
+                   "nine 2, localized english")
+    XCTAssertEqual(R.string.nine.nine3(preferredLanguages: myprefs),
+                   "nine 3, localized base")
+  }
+
+
+  func testEnglishGB() {
+    let myprefs = ["en-GB"]
+
+    XCTAssertEqual(R.string.one.one1(preferredLanguages: myprefs),
+                   "one 1, not localized")
+    XCTAssertEqual(R.string.one.one2(preferredLanguages: myprefs),
+                   "one 2, not localized")
+    XCTAssertEqual(R.string.two.two1(preferredLanguages: myprefs),
+                   "two 1, localized english")
+    XCTAssertEqual(R.string.two.two2("Hello", preferredLanguages: myprefs),
+                   "two 2, Hello localized english")
+    XCTAssertEqual(R.string.three.three1(preferredLanguages: myprefs),
+                   "three 1, localized english")
+    XCTAssertEqual(R.string.three.three2(preferredLanguages: myprefs),
+                   "three 2, localized english")
+    XCTAssertEqual(R.string.three.three3(preferredLanguages: myprefs),
+                   "three3")
+    XCTAssertEqual(R.string.four.four1(preferredLanguages: myprefs),
+                   "four1")
+    XCTAssertEqual(R.string.five.five1(preferredLanguages: myprefs),
+                   "five 1, localized english gb")
+    XCTAssertEqual(R.string.five.five2(preferredLanguages: myprefs),
+                   "five2")
+    XCTAssertEqual(R.string.five.five4(preferredLanguages: myprefs),
+                   "five4")
+    XCTAssertEqual(R.string.six.six1(preferredLanguages: myprefs),
+                   "six 1, localized french")
+    XCTAssertEqual(R.string.six.six2(preferredLanguages: myprefs),
+                   "six 2, localized french")
+    XCTAssertEqual(R.string.seven.seven1(preferredLanguages: myprefs),
+                   "seven 1, localized english")
+    XCTAssertEqual(R.string.seven.seven2(preferredLanguages: myprefs),
+                   "seven 2, localized english")
+    XCTAssertEqual(R.string.seven.seven3(preferredLanguages: myprefs),
+                   "seven3")
+    XCTAssertEqual(R.string.seven.seven4(preferredLanguages: myprefs),
+                   "seven4")
+    XCTAssertEqual(R.string.eight.eight1(preferredLanguages: myprefs),
+                   "eight 1, localized base")
+    XCTAssertEqual(R.string.eight.eight2(preferredLanguages: myprefs),
+                   "eight 2, localized base")
+    XCTAssertEqual(R.string.eight.eight3(preferredLanguages: myprefs),
+                   "eight 3, localized base")
+    XCTAssertEqual(R.string.nine.nine1(preferredLanguages: myprefs),
+                   "nine 1, localized base")
+    XCTAssertEqual(R.string.nine.nine2(preferredLanguages: myprefs),
+                   "nine 2, localized base")
+    XCTAssertEqual(R.string.nine.nine3(preferredLanguages: myprefs),
+                   "nine 3, localized base")
+  }
+
+
+  func testFrench() {
+    let myprefs = ["fr"]
+
+    XCTAssertEqual(R.string.one.one1(preferredLanguages: myprefs),
+                   "one 1, not localized")
+    XCTAssertEqual(R.string.one.one2(preferredLanguages: myprefs),
+                   "one 2, not localized")
+    XCTAssertEqual(R.string.two.two1(preferredLanguages: myprefs),
+                   "two1")
+    XCTAssertEqual(R.string.two.two2("Hello", preferredLanguages: myprefs),
+                   "two2")
+    XCTAssertEqual(R.string.three.three1(preferredLanguages: myprefs),
+                   "three1")
+    XCTAssertEqual(R.string.three.three2(preferredLanguages: myprefs),
+                   "three2")
+    XCTAssertEqual(R.string.three.three3(preferredLanguages: myprefs),
+                   "three3")
+    XCTAssertEqual(R.string.four.four1(preferredLanguages: myprefs),
+                   "four1")
+    XCTAssertEqual(R.string.five.five1(preferredLanguages: myprefs),
+                   "five 1, localized french")
+    XCTAssertEqual(R.string.five.five2(preferredLanguages: myprefs),
+                   "five 2, localized french")
+    XCTAssertEqual(R.string.five.five4(preferredLanguages: myprefs),
+                   "five 4, localized french")
+    XCTAssertEqual(R.string.six.six1(preferredLanguages: myprefs),
+                   "six 1, localized french")
+    XCTAssertEqual(R.string.six.six2(preferredLanguages: myprefs),
+                   "six 2, localized french")
+    XCTAssertEqual(R.string.seven.seven1(preferredLanguages: myprefs),
+                   "seven 1, localized french")
+    XCTAssertEqual(R.string.seven.seven2(preferredLanguages: myprefs),
+                   "seven 2, localized french")
+    XCTAssertEqual(R.string.seven.seven3(preferredLanguages: myprefs),
+                   "seven 3, localized french")
+    XCTAssertEqual(R.string.seven.seven4(preferredLanguages: myprefs),
+                   "seven 4, localized french")
+    XCTAssertEqual(R.string.eight.eight1(preferredLanguages: myprefs),
+                   "eight 1, localized french")
+    XCTAssertEqual(R.string.eight.eight2(preferredLanguages: myprefs),
+                   "eight 2, localized french")
+    XCTAssertEqual(R.string.eight.eight3(preferredLanguages: myprefs),
+                   "eight 3, localized base")
+    XCTAssertEqual(R.string.nine.nine1(preferredLanguages: myprefs),
+                   "nine 1, localized french")
+    XCTAssertEqual(R.string.nine.nine2(preferredLanguages: myprefs),
+                   "nine 2, localized french")
+    XCTAssertEqual(R.string.nine.nine3(preferredLanguages: myprefs),
+                   "nine 3, localized base")
+  }
+
+
+  func testFrenchCanada() {
+    let myprefs = ["fr-CA"]
+
+    XCTAssertEqual(R.string.one.one1(preferredLanguages: myprefs),
+                   "one 1, not localized")
+    XCTAssertEqual(R.string.one.one2(preferredLanguages: myprefs),
+                   "one 2, not localized")
+    XCTAssertEqual(R.string.two.two1(preferredLanguages: myprefs),
+                   "two1")
+    XCTAssertEqual(R.string.two.two2("Hello", preferredLanguages: myprefs),
+                   "two2")
+    XCTAssertEqual(R.string.three.three1(preferredLanguages: myprefs),
+                   "three1")
+    XCTAssertEqual(R.string.three.three2(preferredLanguages: myprefs),
+                   "three2")
+    XCTAssertEqual(R.string.three.three3(preferredLanguages: myprefs),
+                   "three3")
+    XCTAssertEqual(R.string.four.four1(preferredLanguages: myprefs),
+                   "four1")
+    XCTAssertEqual(R.string.five.five1(preferredLanguages: myprefs),
+                   "five 1, localized french canada")
+    XCTAssertEqual(R.string.five.five2(preferredLanguages: myprefs),
+                   "five2")
+    XCTAssertEqual(R.string.five.five4(preferredLanguages: myprefs),
+                   "five4")
+    XCTAssertEqual(R.string.six.six1(preferredLanguages: myprefs),
+                   "six 1, localized french canada")
+    XCTAssertEqual(R.string.six.six2(preferredLanguages: myprefs),
+                   "six2")
+    XCTAssertEqual(R.string.seven.seven1(preferredLanguages: myprefs),
+                   "seven 1, localized french")
+    XCTAssertEqual(R.string.seven.seven2(preferredLanguages: myprefs),
+                   "seven 2, localized french")
+    XCTAssertEqual(R.string.seven.seven3(preferredLanguages: myprefs),
+                   "seven 3, localized french")
+    XCTAssertEqual(R.string.seven.seven4(preferredLanguages: myprefs),
+                   "seven 4, localized french")
+    XCTAssertEqual(R.string.eight.eight1(preferredLanguages: myprefs),
+                   "eight 1, localized base")
+    XCTAssertEqual(R.string.eight.eight2(preferredLanguages: myprefs),
+                   "eight 2, localized base")
+    XCTAssertEqual(R.string.eight.eight3(preferredLanguages: myprefs),
+                   "eight 3, localized base")
+    XCTAssertEqual(R.string.nine.nine1(preferredLanguages: myprefs),
+                   "nine 1, localized base")
+    XCTAssertEqual(R.string.nine.nine2(preferredLanguages: myprefs),
+                   "nine 2, localized base")
+    XCTAssertEqual(R.string.nine.nine3(preferredLanguages: myprefs),
+                   "nine 3, localized base")
+  }
+
+}

--- a/LocalizedStringApp/Podfile
+++ b/LocalizedStringApp/Podfile
@@ -1,0 +1,8 @@
+platform :ios, '10.0'
+
+project 'LocalizedStringApp'
+
+pod 'R.swift.Library', :git => 'https://github.com/mac-cain13/R.swift.Library.git'
+
+target 'LocalizedStringApp'
+target 'LocalizedStringAppTests'

--- a/LocalizedStringApp/Podfile.lock
+++ b/LocalizedStringApp/Podfile.lock
@@ -1,0 +1,21 @@
+PODS:
+  - R.swift.Library (5.1.0.alpha.1)
+
+DEPENDENCIES:
+  - R.swift.Library (from `https://github.com/mac-cain13/R.swift.Library.git`)
+
+EXTERNAL SOURCES:
+  R.swift.Library:
+    :git: https://github.com/mac-cain13/R.swift.Library.git
+
+CHECKOUT OPTIONS:
+  R.swift.Library:
+    :commit: 3365947d725398694d6ed49f2e6622f05ca3fc0f
+    :git: https://github.com/mac-cain13/R.swift.Library.git
+
+SPEC CHECKSUMS:
+  R.swift.Library: d3ec5cbeb41dd3151834246af40cb1081a158244
+
+PODFILE CHECKSUM: e18cab8171402f3acca75e22904e999498269417
+
+COCOAPODS: 1.7.5

--- a/Sources/RswiftCore/Generators/StringsStructGenerator.swift
+++ b/Sources/RswiftCore/Generators/StringsStructGenerator.swift
@@ -344,7 +344,7 @@ private struct StringValues {
     }
 
     if tableName == "Localizable" {
-      return "NSLocalizedString(\"\(escapedKey)\", bundle: \(bundle)\(valueArgument) comment: \"\")"
+      return "NSLocalizedString(\"\(escapedKey)\", bundle: \(bundle)\(valueArgument), comment: \"\")"
     }
     else {
       return "NSLocalizedString(\"\(escapedKey)\", tableName: \"\(tableName)\", bundle: \(bundle)\(valueArgument), comment: \"\")"

--- a/Sources/RswiftCore/Generators/StringsStructGenerator.swift
+++ b/Sources/RswiftCore/Generators/StringsStructGenerator.swift
@@ -244,18 +244,32 @@ struct StringsStructGenerator: ExternalOnlyStructGenerator {
       name: SwiftIdentifier(name: values.key),
       generics: nil,
       parameters: [
-        Function.Parameter(name: "_", type: Type._Void, defaultValue: "()")
+        Function.Parameter(
+          name: "preferredLanguages",
+          type: Type._Array.withGenericArgs([Type._String]).asOptional(),
+          defaultValue: "nil"
+        )
       ],
       doesThrow: false,
       returnType: Type._String,
-      body: "return \(values.localizedString)",
+      body: """
+        guard let preferredLanguages = preferredLanguages else {
+          return \(values.swiftCode(bundle: "hostingBundle"))
+        }
+
+        guard let (_, bundle) = localeBundle(tableName: "\(values.tableName)", preferredLanguages: preferredLanguages) else {
+          return "\(values.key)"
+        }
+
+        return \(values.swiftCode(bundle: "bundle"))
+        """,
       os: []
     )
   }
 
   private func stringFunctionParams(for values: StringValues, at externalAccessLevel: AccessLevel) -> Function {
 
-    let params = values.params.enumerated().map { arg -> Function.Parameter in
+    var params = values.params.enumerated().map { arg -> Function.Parameter in
       let (ix, param) = arg
       let argumentLabel = param.name ?? "_"
       let valueName = "value\(ix + 1)"
@@ -264,6 +278,13 @@ struct StringsStructGenerator: ExternalOnlyStructGenerator {
     }
 
     let args = params.map { $0.localName ?? $0.name }.joined(separator: ", ")
+
+    let prefereredLanguages = Function.Parameter(
+      name: "preferredLanguages",
+      type: Type._Array.withGenericArgs([Type._String]).asOptional(),
+      defaultValue: "nil"
+    )
+    params.append(prefereredLanguages)
 
     return Function(
       availables: [],
@@ -275,7 +296,19 @@ struct StringsStructGenerator: ExternalOnlyStructGenerator {
       parameters: params,
       doesThrow: false,
       returnType: Type._String,
-      body: "return String(format: \(values.localizedString), locale: R.applicationLocale, \(args))",
+      body: """
+        guard let preferredLanguages = preferredLanguages else {
+          let format = \(values.swiftCode(bundle: "hostingBundle"))
+          return String(format: format, locale: applicationLocale, \(args))
+        }
+
+        guard let (locale, bundle) = localeBundle(tableName: "\(values.tableName)", preferredLanguages: preferredLanguages) else {
+          return "\(values.key)"
+        }
+
+        let format = \(values.swiftCode(bundle: "bundle"))
+        return String(format: format, locale: locale, \(args))
+        """,
       os: []
     )
   }
@@ -302,28 +335,28 @@ private struct StringValues {
   let values: [(Locale, String)]
   let developmentLanguage: String
 
-  var localizedString: String {
+  func swiftCode(bundle: String) -> String {
     let escapedKey = key.escapedStringLiteral
 
     var valueArgument: String = ""
-    if let value = primaryLanguageValue {
+    if let value = baseLanguageValue {
       valueArgument = ", value: \"\(value.escapedStringLiteral)\""
     }
 
     if tableName == "Localizable" {
-      return "NSLocalizedString(\"\(escapedKey)\", bundle: R.hostingBundle\(valueArgument), comment: \"\")"
+      return "NSLocalizedString(\"\(escapedKey)\", bundle: \(bundle)\(valueArgument) comment: \"\")"
     }
     else {
-      return "NSLocalizedString(\"\(escapedKey)\", tableName: \"\(tableName)\", bundle: R.hostingBundle\(valueArgument), comment: \"\")"
+      return "NSLocalizedString(\"\(escapedKey)\", tableName: \"\(tableName)\", bundle: \(bundle)\(valueArgument), comment: \"\")"
     }
+  }
+
+  var baseLanguageValue: String? {
+    return values.filter { $0.0.isBase }.map { $0.1 }.first
   }
 
   private var primaryLanguageValues:  [(Locale, String)] {
     return values.filter { $0.0.isBase } + values.filter { $0.0.language == developmentLanguage }
-  }
-
-  private var primaryLanguageValue: String? {
-    return primaryLanguageValues.map { $0.1 }.first
   }
 
   var comments: [String] {

--- a/Sources/RswiftCore/SwiftTypes/CodeGenerators/TypePrinter.swift
+++ b/Sources/RswiftCore/SwiftTypes/CodeGenerators/TypePrinter.swift
@@ -17,20 +17,24 @@ struct TypePrinter: SwiftCodeConverible, UsedTypesProvider {
   }
 
   var swiftCode: String {
-    let optionalString = type.optional ? "?" : ""
+    let optionalSuffix = type.optional ? "?" : ""
+    let args = type.genericArgs.map { $0.description }.joined(separator: ", ")
 
     let withoutModule: String
-    if type.genericArgs.count > 0 {
-      let args = type.genericArgs.map { $0.description }.joined(separator: ", ")
-      withoutModule = "\(type.name)<\(args)>\(optionalString)"
+    if type.genericArgs.isEmpty {
+      withoutModule = "\(type.name)"
+    } else if type.name == Type._Tuple.name {
+      withoutModule = "(\(args))"
+    } else if type.name == Type._Array.name {
+      withoutModule = "[\(args)]"
     } else {
-      withoutModule = "\(type.name)\(optionalString)"
+      withoutModule = "\(type.name)<\(args)>"
     }
 
     if case let .custom(name: moduleName) = type.module {
-      return "\(moduleName).\(withoutModule)"
+      return "\(moduleName).\(withoutModule)\(optionalSuffix)"
     } else {
-      return withoutModule
+      return "\(withoutModule)\(optionalSuffix)"
     }
   }
 

--- a/Sources/RswiftCore/SwiftTypes/Function.swift
+++ b/Sources/RswiftCore/SwiftTypes/Function.swift
@@ -32,7 +32,7 @@ struct Function: UsedTypesProvider, SwiftCodeConverible {
   }
 
   var swiftCode: String {
-    let commentsString = comments.map { "/// \($0)\n" }.joined(separator: "")
+    let commentsString = comments.map { $0.isEmpty ? "///\n" : "/// \($0)\n" }.joined(separator: "")
     let availablesString = availables.map { "@available(\($0))\n" }.joined(separator: "")
     let accessModifierString = accessModifier.swiftCode
     let staticString = isStatic ? "static " : ""

--- a/Sources/RswiftCore/SwiftTypes/Let.swift
+++ b/Sources/RswiftCore/SwiftTypes/Let.swift
@@ -47,7 +47,7 @@ struct Let: UsedTypesProvider, SwiftCodeConverible {
   }
 
   var swiftCode: String {
-    let commentsString = comments.map { "/// \($0)\n" }.joined(separator: "")
+    let commentsString = comments.map { $0.isEmpty ? "///\n" : "/// \($0)\n" }.joined(separator: "")
     let accessModifierString = accessModifier.swiftCode
     let staticString = isStatic ? "static " : ""
 

--- a/Sources/RswiftCore/SwiftTypes/Struct.swift
+++ b/Sources/RswiftCore/SwiftTypes/Struct.swift
@@ -43,7 +43,7 @@ struct Struct: UsedTypesProvider, SwiftCodeConverible {
   }
 
   var swiftCode: String {
-    let commentsString = comments.map { "/// \($0)\n" }.joined(separator: "")
+    let commentsString = comments.map { $0.isEmpty ? "///\n" : "/// \($0)\n" }.joined(separator: "")
     let availablesString = availables.map { "@available(\($0))\n" }.joined(separator: "")
     let accessModifierString = accessModifier.swiftCode
     let implementsString = implements.count > 0 ? ": " + implements.map { $0.swiftCode }.joined(separator: ", ") : ""

--- a/Sources/RswiftCore/SwiftTypes/Type.swift
+++ b/Sources/RswiftCore/SwiftTypes/Type.swift
@@ -22,6 +22,8 @@ struct Type: UsedTypesProvider, CustomStringConvertible, Hashable {
   static let _Any = Type(module: .stdLib, name: "Any")
   static let _AnyObject = Type(module: .stdLib, name: "AnyObject")
   static let _String = Type(module: .stdLib, name: "String")
+  static let _Array = Type(module: .stdLib, name: "Array")
+  static let _Tuple = Type(module: .stdLib, name: "_TUPLE_")
   static let _Int = Type(module: .stdLib, name: "Int")
   static let _UInt = Type(module: .stdLib, name: "UInt")
   static let _Double = Type(module: .stdLib, name: "Double")
@@ -103,8 +105,4 @@ struct Type: UsedTypesProvider, CustomStringConvertible, Hashable {
   func withGenericArgs(_ genericArgs: [Type]) -> Type {
     return Type(module: module, name: name, genericArgs: genericArgs, optional: optional)
   }
-}
-
-func ==(lhs: Type, rhs: Type) -> Bool {
-  return (lhs.description == rhs.description)
 }

--- a/Sources/RswiftCore/Util/Struct+InternalProperties.swift
+++ b/Sources/RswiftCore/Util/Struct+InternalProperties.swift
@@ -32,8 +32,84 @@ extension Struct {
       Class(accessModifier: .filePrivate, type: Type(module: .host, name: "Class"))
     ]
 
+    let internalFunctions = [
+      Function(
+        availables: [],
+        comments: ["Find first language and bundle for which the table exists"],
+        accessModifier: .filePrivate,
+        isStatic: true,
+        name: "localeBundle",
+        generics: nil,
+        parameters: [
+          .init(name: "tableName", type: Type._String),
+          .init(name: "preferredLanguages", type: Type._Array.withGenericArgs([Type._String]))
+        ],
+        doesThrow: false,
+        returnType: Type._Tuple.withGenericArgs([Type._Locale, Type._Bundle]).asOptional(),
+        body: """
+          var languages = preferredLanguages
+            .map(Locale.init)
+            .filter { locale in
+              return hostingBundle.localizations.contains(locale.identifier)
+                || hostingBundle.localizations.contains(locale.languageCode ?? "")
+            }
+            .flatMap { locale -> [String] in
+              if let language = locale.languageCode {
+                return [locale.identifier, language]
+              }
+              return [locale.identifier]
+            }
+
+          if languages.isEmpty {
+            if let developmentLocalization = hostingBundle.developmentLocalization {
+              languages = [developmentLocalization]
+            }
+          } else {
+            // Insert Base as second item
+            if languages.count > 1 {
+              languages.insert("Base", at: 1)
+            } else {
+              languages.append("Base")
+            }
+
+            // Add development language as backstops
+            if let developmentLocalization = hostingBundle.developmentLocalization {
+              languages.append(developmentLocalization)
+            }
+          }
+
+          // Find first language for which table exists
+          // Note: key might not exist in chosen language (in that case, key will be shown)
+          for language in languages {
+            if let lproj = hostingBundle.url(forResource: language, withExtension: "lproj"),
+               let lbundle = Bundle(url: lproj)
+            {
+              let strings = lbundle.url(forResource: tableName, withExtension: "strings")
+              let stringsdict = lbundle.url(forResource: tableName, withExtension: "stringsdict")
+
+              if strings != nil || stringsdict != nil {
+                return (Locale(identifier: language), lbundle)
+              }
+            }
+          }
+
+          // If table is available in main bundle, don't look for localized resources
+          let strings = hostingBundle.url(forResource: tableName, withExtension: "strings", subdirectory: nil, localization: nil)
+          let stringsdict = hostingBundle.url(forResource: tableName, withExtension: "stringsdict", subdirectory: nil, localization: nil)
+
+          if strings != nil || stringsdict != nil {
+            return (applicationLocale, hostingBundle)
+          }
+
+          // If table is not found for requested languages, key will be shown
+          return nil
+          """,
+        os: [])
+    ]
+
     var externalStruct = self
     externalStruct.properties.append(contentsOf: internalProperties)
+    externalStruct.functions.append(contentsOf: internalFunctions)
     externalStruct.classes.append(contentsOf: internalClasses)
 
     return externalStruct

--- a/Sources/RswiftCore/Util/UtilExtensions.swift
+++ b/Sources/RswiftCore/Util/UtilExtensions.swift
@@ -55,8 +55,10 @@ extension String {
   }
 
   func indent(with indentation: String) -> String {
-    let components = self.components(separatedBy: "\n")
-    return indentation + components.joined(separator: "\n\(indentation)")
+    return self
+      .components(separatedBy: "\n")
+      .map { line in line .isEmpty ? "" : "\(indentation)\(line)" }
+      .joined(separator: "\n")
   }
 
   var fullRange: NSRange {


### PR DESCRIPTION
Adds optional `preferredLanguages` parameter to generated strings functions. Used as a replacement for `Locale.preferredLanguages`.

Usage:

```swift
// Assuming the app is localised in English and French
// Returns French localisation, even if Phone is set to English
let hello = R.string.welcome.hello(preferredLanguages: ["nl", "fr"])
```

Fixes https://github.com/mac-cain13/R.swift/issues/219