### PR TITLE
SegueGenerator: Skip segues that have an empty identifier

### DIFF
--- a/ResourceApp/ResourceApp.xcodeproj/project.pbxproj
+++ b/ResourceApp/ResourceApp.xcodeproj/project.pbxproj
@@ -81,6 +81,7 @@
 		D5F05D481BB520B1003AE55E /* FilesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5F05D471BB520B1003AE55E /* FilesTests.swift */; };
 		D5FAD9091B63B05700ECE230 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D55C6CC61B5D757300301B0D /* Images.xcassets */; };
 		D80B9E2AC049322EF7FFB2BA /* Pods_Shared_ResourceApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BA2177EF715BB7F766BD6216 /* Pods_Shared_ResourceApp.framework */; };
+		DD0CD0C4232A950A00A555A3 /* SegueIdentifiers.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DD0CD0C3232A950A00A555A3 /* SegueIdentifiers.storyboard */; };
 		DEF5599A1CA4873D009B8C51 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF559991CA4873D009B8C51 /* AppDelegate.swift */; };
 		DEF5599F1CA4873D009B8C51 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DEF5599D1CA4873D009B8C51 /* Main.storyboard */; };
 		DEF559A11CA4873D009B8C51 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DEF559A01CA4873D009B8C51 /* Assets.xcassets */; };
@@ -252,6 +253,7 @@
 		D5F05D431BB52063003AE55E /* Duplicate.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = Duplicate.json; sourceTree = "<group>"; };
 		D5F05D451BB52078003AE55E /* duplicateJson */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = duplicateJson; sourceTree = "<group>"; };
 		D5F05D471BB520B1003AE55E /* FilesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FilesTests.swift; sourceTree = "<group>"; };
+		DD0CD0C3232A950A00A555A3 /* SegueIdentifiers.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = SegueIdentifiers.storyboard; sourceTree = "<group>"; };
 		DEF559971CA4873D009B8C51 /* ResourceApp-tvOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "ResourceApp-tvOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		DEF559991CA4873D009B8C51 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		DEF5599E1CA4873D009B8C51 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
@@ -475,6 +477,7 @@
 				E25984A022AEE89B00467E1E /* CustomSegue.swift */,
 				D55C6CBF1B5D757300301B0D /* FirstViewController.swift */,
 				D5CBCE481B7682B800C5D96B /* MyViewController.swift */,
+				DD0CD0C3232A950A00A555A3 /* SegueIdentifiers.storyboard */,
 				D55C6CC11B5D757300301B0D /* SecondViewController.swift */,
 				D55C6CC61B5D757300301B0D /* Images.xcassets */,
 				CCBC9CB81EC4809D002F3D0E /* Images2.xcassets */,
@@ -830,6 +833,7 @@
 				D50175BE1B5FEFD000DB8314 /* Secondary.storyboard in Resources */,
 				D5AD5C911B78FC0500A8B96C /* duplicate.xib in Resources */,
 				D575E25D1B766CD800C22F0B /* My View.xib in Resources */,
+				DD0CD0C4232A950A00A555A3 /* SegueIdentifiers.storyboard in Resources */,
 				D5AD5C941B78FC4E00A8B96C /* Duplicate.xib in Resources */,
 				E2CD68671D7CADEA00BEBE59 /* hello.txt in Resources */,
 				D55C6CC51B5D757300301B0D /* Main.storyboard in Resources */,

--- a/ResourceApp/ResourceApp/References.storyboard
+++ b/ResourceApp/ResourceApp/References.storyboard
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14810.11" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="IfC-nk-yIu">
-    <device id="retina4_7" orientation="portrait" appearance="light"/>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="IfC-nk-yIu">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
         <deployment version="4352" identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14766.13"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -26,6 +28,7 @@
                         <segue destination="IcN-B5-zUv" kind="show" identifier="toAVPlayerController" id="5eO-0j-fVU"/>
                         <segue destination="kne-1k-ozT" kind="show" identifier="toSomeStoryboard" id="b6z-Sc-6eL"/>
                         <segue destination="Zbd-89-K73" kind="show" identifier="toUnknown" id="6N8-Dg-FOm"/>
+                        <segue destination="u1T-ai-agK" kind="show" identifier="" id="oqv-1x-7pF"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="H3t-vu-4W6" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -64,10 +67,28 @@
             </objects>
             <point key="canvasLocation" x="768.5" y="121"/>
         </scene>
+        <!--View Controller-->
+        <scene sceneID="fd2-1N-CYg">
+            <objects>
+                <viewController id="u1T-ai-agK" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="0Em-Bg-9d0"/>
+                        <viewControllerLayoutGuide type="bottom" id="Zd6-E6-4pe"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="Nqg-7c-dWU">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="7Ta-hL-My2" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="244" y="581"/>
+        </scene>
     </scenes>
     <resources>
         <namedColor name="My Red">
-            <color red="0.72156864404678345" green="0.027450980618596077" blue="0.10196078568696976" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+            <color red="0.87843137979507446" green="0.43921568989753723" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
         </namedColor>
     </resources>
 </document>

--- a/ResourceApp/ResourceApp/References.storyboard
+++ b/ResourceApp/ResourceApp/References.storyboard
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="IfC-nk-yIu">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14810.11" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="IfC-nk-yIu">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment version="4352" identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14766.13"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -28,7 +26,6 @@
                         <segue destination="IcN-B5-zUv" kind="show" identifier="toAVPlayerController" id="5eO-0j-fVU"/>
                         <segue destination="kne-1k-ozT" kind="show" identifier="toSomeStoryboard" id="b6z-Sc-6eL"/>
                         <segue destination="Zbd-89-K73" kind="show" identifier="toUnknown" id="6N8-Dg-FOm"/>
-                        <segue destination="u1T-ai-agK" kind="show" identifier="" id="oqv-1x-7pF"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="H3t-vu-4W6" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -67,28 +64,10 @@
             </objects>
             <point key="canvasLocation" x="768.5" y="121"/>
         </scene>
-        <!--View Controller-->
-        <scene sceneID="fd2-1N-CYg">
-            <objects>
-                <viewController id="u1T-ai-agK" sceneMemberID="viewController">
-                    <layoutGuides>
-                        <viewControllerLayoutGuide type="top" id="0Em-Bg-9d0"/>
-                        <viewControllerLayoutGuide type="bottom" id="Zd6-E6-4pe"/>
-                    </layoutGuides>
-                    <view key="view" contentMode="scaleToFill" id="Nqg-7c-dWU">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                    </view>
-                </viewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="7Ta-hL-My2" userLabel="First Responder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="244" y="581"/>
-        </scene>
     </scenes>
     <resources>
         <namedColor name="My Red">
-            <color red="0.87843137979507446" green="0.43921568989753723" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+            <color red="0.72156864404678345" green="0.027450980618596077" blue="0.10196078568696976" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
         </namedColor>
     </resources>
 </document>

--- a/ResourceApp/ResourceApp/SegueIdentifiers.storyboard
+++ b/ResourceApp/ResourceApp/SegueIdentifiers.storyboard
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="Elh-lG-SSX">
+            <objects>
+                <viewController storyboardIdentifier="fooController" id="HrG-n6-FlD" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="vwT-hP-vDh">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ng3-RU-Omo">
+                                <rect key="frame" x="179.5" y="433" width="55" height="30"/>
+                                <state key="normal" title="Tap me!"/>
+                                <connections>
+                                    <segue destination="ZNm-In-nYu" kind="show" identifier="" id="caA-qX-mBE"/>
+                                </connections>
+                            </button>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstItem="ng3-RU-Omo" firstAttribute="centerX" secondItem="vwT-hP-vDh" secondAttribute="centerX" id="3d8-jg-zUX"/>
+                            <constraint firstItem="ng3-RU-Omo" firstAttribute="centerY" secondItem="vwT-hP-vDh" secondAttribute="centerY" id="Oul-Jw-qVS"/>
+                        </constraints>
+                        <viewLayoutGuide key="safeArea" id="X6S-rH-NiE"/>
+                    </view>
+                    <connections>
+                        <segue destination="3xr-4N-OFV" kind="show" identifier="goToBaz" id="2ar-g5-qcn"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="ZFb-TE-cAg" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-467" y="84"/>
+        </scene>
+        <!--View Controller-->
+        <scene sceneID="ojs-Ki-Ii5">
+            <objects>
+                <viewController storyboardIdentifier="barController" id="ZNm-In-nYu" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="NNW-lF-hGd">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <viewLayoutGuide key="safeArea" id="wPw-97-s3b"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="xXW-ou-FAU" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="380" y="-427"/>
+        </scene>
+        <!--View Controller-->
+        <scene sceneID="inW-58-91J">
+            <objects>
+                <viewController storyboardIdentifier="bazController" id="3xr-4N-OFV" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="NY0-ZZ-TOt">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <viewLayoutGuide key="safeArea" id="fOE-qb-xRY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="WjL-NR-bo9" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="381" y="269"/>
+        </scene>
+    </scenes>
+</document>

--- a/ResourceApp/ResourceAppTests/ResourceAppTests.swift
+++ b/ResourceApp/ResourceAppTests/ResourceAppTests.swift
@@ -43,6 +43,8 @@ class ResourceAppTests: XCTestCase {
     warning: [R.swift] Skipping string for key FormatSpecifiers5 (Settings), format specifiers don't match for all locales: Base, nl
     warning: [R.swift] Skipping string for key mismatch (Settings), format specifiers don't match for all locales: Base, nl
     warning: [R.swift] Skipping 1 string in 'Generic' because no swift identifier can be generated for key: '#'
+    warning: [R.swift] Strings file 'Settings' (nl) has extra translations (not in Base) for keys: 'Only Dutch'
+    warning: [R.swift] Strings file 'Generic' has extra translations (not in English) for keys: '#'
     """
     .trimmingCharacters(in: .whitespacesAndNewlines)
     .components(separatedBy: "\n")

--- a/Sources/RswiftCore/Generators/SegueGenerator.swift
+++ b/Sources/RswiftCore/Generators/SegueGenerator.swift
@@ -44,6 +44,10 @@ struct SegueStructGenerator: ExternalOnlyStructGenerator {
             return nil
           }
 
+          guard !segue.identifier.isEmpty else {
+            return nil
+          }
+
           return SegueWithInfo(segue: segue, sourceType: viewController.type, destinationType: destinationType)
         }
       }


### PR DESCRIPTION
This PR causes the generator to skip any segues with an empty string identifier.

For some types of segues, such as from a UIButton to another view controller, a segue identifier is not required. When it **is** required, for example in a view controller initiated segue, Xcode will warn the user about it already, so R.swift doesn't need to warn about either case.

I'm not sure if I fixed it in the correct place, please let me know if you know a better way. :)

Closes #525