### PR TITLE
Introduce useDevelopmentLanguageDefaults option

### DIFF
--- a/Sources/RswiftCore/CallInformation.swift
+++ b/Sources/RswiftCore/CallInformation.swift
@@ -18,6 +18,7 @@ public struct CallInformation {
   let generators: [Generator]
   let accessLevel: AccessLevel
   let imports: [Module]
+  let useDevelopmentLanguageDefaults: Bool
 
   let xcodeprojURL: URL
   let targetName: String
@@ -44,6 +45,7 @@ public struct CallInformation {
     generators: [Generator],
     accessLevel: AccessLevel,
     imports: [Module],
+    useDevelopmentLanguageDefaults: Bool,
 
     xcodeprojURL: URL,
     targetName: String,
@@ -69,6 +71,7 @@ public struct CallInformation {
     self.accessLevel = accessLevel
     self.imports = imports
     self.generators = generators
+    self.useDevelopmentLanguageDefaults = useDevelopmentLanguageDefaults
 
     self.xcodeprojURL = xcodeprojURL
     self.targetName = targetName

--- a/Sources/RswiftCore/RswiftCore.swift
+++ b/Sources/RswiftCore/RswiftCore.swift
@@ -74,7 +74,10 @@ public struct RswiftCore {
         structGenerators.append(ResourceFileStructGenerator(resourceFiles: resources.resourceFiles))
       }
       if callInformation.generators.contains(.string) {
-        structGenerators.append(StringsStructGenerator(localizableStrings: resources.localizableStrings, developmentLanguage: xcodeproj.developmentLanguage))
+        structGenerators.append(StringsStructGenerator(localizableStrings: resources.localizableStrings, 
+                                                       developmentLanguage: xcodeproj.developmentLanguage,
+                                                       useDevelopmentLanguageDefaults: callInformation.useDevelopmentLanguageDefaults))
+
       }
       if callInformation.generators.contains(.id) {
         structGenerators.append(AccessibilityIdentifierStructGenerator(nibs: resources.nibs, storyboards: resources.storyboards))

--- a/Sources/rswift/main.swift
+++ b/Sources/rswift/main.swift
@@ -72,6 +72,7 @@ struct CommanderOptions {
   static let importModules = Option("import", default: "", description: "Add extra modules as import in the generated file, comma seperated")
   static let accessLevel = Option("accessLevel", default: AccessLevel.internalLevel, description: "The access level [public|internal] to use for the generated R-file")
   static let rswiftIgnore = Option("rswiftignore", default: ".rswiftignore", description: "Path to pattern file that describes files that should be ignored")
+  static let useDevelopmentLanguageDefaults = Flag("use-development-language-defaults", description: "If true, The generated LocalizedString macros will use the development language values as the default for cases where Base localization is not in use")
   static let inputOutputFilesValidation = Flag("input-output-files-validation", default: true, flag: nil, disabledName: "disable-input-output-files-validation", disabledFlag: nil, description: "Validate input and output files configured in a build phase")
 }
 
@@ -105,10 +106,11 @@ let generate = command(
   CommanderOptions.importModules,
   CommanderOptions.accessLevel,
   CommanderOptions.rswiftIgnore,
+  CommanderOptions.useDevelopmentLanguageDefaults,
   CommanderOptions.inputOutputFilesValidation,
 
   CommanderArguments.outputPath
-) { generatorNames, uiTestOutputPath, importModules, accessLevel, rswiftIgnore, inputOutputFilesValidation, outputPath in
+) { generatorNames, uiTestOutputPath, importModules, accessLevel, rswiftIgnore, useDevelopmentLanguageDefaults, inputOutputFilesValidation, outputPath in
 
   let processInfo = ProcessInfo()
 
@@ -202,6 +204,7 @@ let generate = command(
     generators: generators,
     accessLevel: accessLevel,
     imports: modules,
+    useDevelopmentLanguageDefaults: useDevelopmentLanguageDefaults,
 
     xcodeprojURL: URL(fileURLWithPath: xcodeprojPath),
     targetName: targetName,


### PR DESCRIPTION
## The problem this PR is trying to solve:
https://github.com/mac-cain13/R.swift/issues/563

## What this PR does:
This PR introduces a new flag `use-development-language-defaults` which when passed will cause the NSLocalizedString macros to have the `value:` option set to the translation value in the developmentLanguage if such a value is available and we are not using base localization.

## Testing
- I could really use some insight on how to properly unit test this behavior.

## End notes
First time opening a PR, please let me know if I missed something. I love this project and use it in pretty much all my apps. I think it would be great to have this functionality but please let me know if you think otherwise :)