### PR TITLE
Add `static let allImages` array to namespaced image folders

### DIFF
--- a/Sources/RswiftCore/Generators/ColorStructGenerator.swift
+++ b/Sources/RswiftCore/Generators/ColorStructGenerator.swift
@@ -124,6 +124,14 @@ private extension NamespacedAssetSubfolder {
           value: "Rswift.ColorResource(bundle: R.hostingBundle, name: \"\(colorPath)\(name)\")"
         )
     }
+	
+	let allColorNames = colorLets.map { $0.name.description }
+	let allColorsLet = Let(comments: ["An array of all color assets contained in this namespaced folder (not including subfolders)"],
+						   accessModifier: externalAccessLevel,
+						   isStatic: true,
+						   name: "allColors",
+						   typeDefinition: .specified(Type._Array.withGenericArgs([Type.ColorResource])),
+						   value: "[" + allImageNames.joined(separator: ", ") + "]")
 
     return Struct(
       availables: [],
@@ -132,7 +140,7 @@ private extension NamespacedAssetSubfolder {
       type: Type(module: .host, name: structName),
       implements: [],
       typealiasses: [],
-      properties: colorLets,
+      properties: [allColorsLet] + colorLets,
       functions: groupedFunctions.uniques.map { colorFunction(for: $0, at: externalAccessLevel, prefix: qualifiedName) },
       structs: structs,
       classes: [],

--- a/Sources/RswiftCore/Generators/ColorStructGenerator.swift
+++ b/Sources/RswiftCore/Generators/ColorStructGenerator.swift
@@ -131,7 +131,7 @@ private extension NamespacedAssetSubfolder {
 						   isStatic: true,
 						   name: "allColors",
 						   typeDefinition: .specified(Type._Array.withGenericArgs([Type.ColorResource])),
-						   value: "[" + allImageNames.joined(separator: ", ") + "]")
+						   value: "[" + allColorNames.joined(separator: ", ") + "]")
 
     return Struct(
       availables: [],

--- a/Sources/RswiftCore/Generators/ImageStructGenerator.swift
+++ b/Sources/RswiftCore/Generators/ImageStructGenerator.swift
@@ -133,6 +133,14 @@ private extension NamespacedAssetSubfolder {
           value: "Rswift.ImageResource(bundle: R.hostingBundle, name: \"\(imagePath)\(name)\")"
         )
     }
+	
+	let allImageNames = imageLets.map { $0.name.description }
+	let allImagesLet = Let(comments: ["An array of all image assets contained in this namespaced folder (not including subfolders)"],
+						   accessModifier: externalAccessLevel,
+						   isStatic: true,
+						   name: "allImages",
+						   typeDefinition: .inferred(Type._Array.withGenericArgs([Type.ImageResource])),
+						   value: "[" + allImageNames.joined(separator: ", ") + "]")
 
     return Struct(
       availables: [],
@@ -141,7 +149,7 @@ private extension NamespacedAssetSubfolder {
       type: Type(module: .host, name: structName),
       implements: [],
       typealiasses: [],
-      properties: imageLets,
+	  properties: [allImagesLet] + imageLets,
       functions: groupedFunctions.uniques.map { imageFunction(for: $0, at: externalAccessLevel, prefix: qualifiedName) },
       structs: structs,
       classes: [],

--- a/Sources/RswiftCore/Generators/ImageStructGenerator.swift
+++ b/Sources/RswiftCore/Generators/ImageStructGenerator.swift
@@ -139,7 +139,7 @@ private extension NamespacedAssetSubfolder {
 						   accessModifier: externalAccessLevel,
 						   isStatic: true,
 						   name: "allImages",
-						   typeDefinition: .inferred(Type._Array.withGenericArgs([Type.ImageResource])),
+						   typeDefinition: .specified(Type._Array.withGenericArgs([Type.ImageResource])),
 						   value: "[" + allImageNames.joined(separator: ", ") + "]")
 
     return Struct(


### PR DESCRIPTION
This addition allows us to safely get an array of all the images contained within a namespaced folder
- it was chosen to only make this available for namespaced folders, as this indicates these images are semantically grouped
- this is particularly useful where we want to dynamically (or randomly) pick an image from this group whilst maintaining the safety of R.swift