### PR TITLE
fix: url(with:) is only availale in iOS 9.0

### DIFF
--- a/Sources/RswiftCore/RswiftCore.swift
+++ b/Sources/RswiftCore/RswiftCore.swift
@@ -33,6 +33,7 @@ public struct RswiftCore {
     self.callInformation = callInformation
   }
 
+  @available(iOS 9.0, *)
   public func run() throws {
     do {
       let xcodeproj = try Xcodeproj(url: callInformation.xcodeprojURL)
@@ -160,6 +161,7 @@ public struct RswiftCore {
   }
 }
 
+@available(iOS 9.0, *)
 private func loadPropertyList(name: String, path: Path?, callInformation: CallInformation) -> PropertyList? {
   guard let path = path else { return nil }
   do {


### PR DESCRIPTION
Used RSwift with SwiftUI, had to do this to make the preview works. Although I'm not sure this is the proper way of addressing the problem. (Did same PR also on XCodeEdit see https://github.com/tomlokhorst/XcodeEdit/pull/41)