### PR TITLE
Alternative for SPM dynamic linking

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,8 @@ let package = Package(
     .macOS(.v10_11)
   ],
   products: [
-    .executable(name: "rswift", targets: ["rswift"])
+    .executable(name: "rswift", targets: ["rswift"]),
+    .executable(name: "rswift-dynamic", type: .dynamic, targets: ["rswift"])
   ],
   dependencies: [
     .package(url: "https://github.com/kylef/Commander.git", from: "0.8.0"),


### PR DESCRIPTION
We need [dynamic linking](https://github.com/apple/swift-package-manager/blob/master/Documentation/PackageDescription.md#methods-2) for this dependence.