### PR TITLE
Support for namespaced file directories

### DIFF
--- a/Sources/RswiftCore/ResourceTypes/Resources.swift
+++ b/Sources/RswiftCore/ResourceTypes/Resources.swift
@@ -51,7 +51,7 @@ struct Resources {
       }
 
       // All previous assets can also possibly be used as files
-      if let resourceFile = tryResourceParsing({ try ResourceFile(url: url) }) {
+      if let resourceFile = tryResourceParsing({ try ResourceFile(url: url, fileManager: fileManager) }) {
         resourceFiles.append(resourceFile)
       }
     }


### PR DESCRIPTION
This PR adds support for file resources that are in a Namespaced directory (ie. imported into the xcode project as a directory vs as a group).

For example, in one of my projects I include a directory of sound files that is included in my target. This addition means that R.Swift correctly recognises those files and provides safe access 👍 