### PR TITLE
Added color support for WatchOS

### DIFF
--- a/Sources/RswiftCore/Generators/ColorStructGenerator.swift
+++ b/Sources/RswiftCore/Generators/ColorStructGenerator.swift
@@ -9,6 +9,58 @@
 
 import Foundation
 
+fileprivate func colorFunction(for name: String, at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier) -> Function {
+  let structName = SwiftIdentifier(name: name)
+  let qualifiedName = prefix + structName
+
+  return Function(
+    availables: ["tvOS 11.0, *", "iOS 11.0, *"],
+    comments: ["`UIColor(named: \"\(name)\", bundle: ..., traitCollection: ...)`"],
+    accessModifier: externalAccessLevel,
+    isStatic: true,
+    name: structName,
+    generics: nil,
+    parameters: [
+      Function.Parameter(
+        name: "compatibleWith",
+        localName: "traitCollection",
+        type: Type._UITraitCollection.asOptional(),
+        defaultValue: "nil"
+      )
+    ],
+    doesThrow: false,
+    returnType: Type._UIColor.asOptional(),
+    body: "return UIKit.UIColor(resource: \(qualifiedName), compatibleWith: traitCollection)",
+    os: ["iOS", "tvOS"]
+  )
+}
+
+fileprivate func watchOSColorFunction(for name: String, at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier) -> Function {
+  let structName = SwiftIdentifier(name: name)
+  let qualifiedName = prefix + structName
+
+  return Function(
+    availables: ["watchOSApplicationExtension 4.0, *"],
+    comments: ["`UIColor(named: \"\(name)\", bundle: ..., traitCollection: ...)`"],
+    accessModifier: externalAccessLevel,
+    isStatic: true,
+    name: structName,
+    generics: nil,
+    parameters: [
+      Function.Parameter(
+        name: "compatibleWith",
+        localName: "traitCollection",
+        type: Type._Any.asOptional(), // We're doing this because UITraitCollection is not present on WatchOS
+        defaultValue: "nil"
+      )
+    ],
+    doesThrow: false,
+    returnType: Type._UIColor.asOptional(),
+    body: "return UIKit.UIColor(named: \(qualifiedName).name)",
+    os: ["watchOS"]
+  )
+}
+
 struct ColorStructGenerator: ExternalOnlyStructGenerator {
   private let assetFolders: [AssetFolder]
 
@@ -57,38 +109,15 @@ struct ColorStructGenerator: ExternalOnlyStructGenerator {
       implements: [],
       typealiasses: [],
       properties: colorLets,
-      functions: groupedColors.uniques.map { colorFunction(for: $0, at: externalAccessLevel, prefix: qualifiedName) },
+      functions: groupedColors.uniques.map { [ colorFunction(for: $0, at: externalAccessLevel, prefix: qualifiedName),
+                                               watchOSColorFunction(for: $0, at: externalAccessLevel, prefix: qualifiedName)] }.flatMap { $0 },
       structs: structs,
       classes: [],
       os: []
     )
   }
 
-  private func colorFunction(for name: String, at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier) -> Function {
-    let structName = SwiftIdentifier(name: name)
-    let qualifiedName = prefix + structName
 
-    return Function(
-      availables: ["tvOS 11.0, *", "iOS 11.0, *"],
-      comments: ["`UIColor(named: \"\(name)\", bundle: ..., traitCollection: ...)`"],
-      accessModifier: externalAccessLevel,
-      isStatic: true,
-      name: structName,
-      generics: nil,
-      parameters: [
-        Function.Parameter(
-          name: "compatibleWith",
-          localName: "traitCollection",
-          type: Type._UITraitCollection.asOptional(),
-          defaultValue: "nil"
-        )
-      ],
-      doesThrow: false,
-      returnType: Type._UIColor.asOptional(),
-      body: "return UIKit.UIColor(resource: \(qualifiedName), compatibleWith: traitCollection)",
-      os: ["iOS", "tvOS"]
-    )
-  }
 }
 
 private extension NamespacedAssetSubfolder {
@@ -133,36 +162,11 @@ private extension NamespacedAssetSubfolder {
       implements: [],
       typealiasses: [],
       properties: colorLets,
-      functions: groupedFunctions.uniques.map { colorFunction(for: $0, at: externalAccessLevel, prefix: qualifiedName) },
+      functions: groupedFunctions.uniques.map { [ colorFunction(for: $0, at: externalAccessLevel, prefix: qualifiedName),
+                                                  watchOSColorFunction(for: $0, at: externalAccessLevel, prefix: qualifiedName)] }.flatMap { $0 },
       structs: structs,
       classes: [],
       os: []
-    )
-  }
-
-  private func colorFunction(for name: String, at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier) -> Function {
-    let structName = SwiftIdentifier(name: name)
-    let qualifiedName = prefix + structName
-
-    return Function(
-      availables: ["tvOS 11.0, *", "iOS 11.0, *"],
-      comments: ["`UIColor(named: \"\(name)\", bundle: ..., traitCollection: ...)`"],
-      accessModifier: externalAccessLevel,
-      isStatic: true,
-      name: structName,
-      generics: nil,
-      parameters: [
-        Function.Parameter(
-          name: "compatibleWith",
-          localName: "traitCollection",
-          type: Type._UITraitCollection.asOptional(),
-          defaultValue: "nil"
-        )
-      ],
-      doesThrow: false,
-      returnType: Type._UIColor.asOptional(),
-      body: "return UIKit.UIColor(resource: \(qualifiedName), compatibleWith: traitCollection)",
-      os: ["iOS", "tvOS"]
     )
   }
 }


### PR DESCRIPTION
I've run into the same issue as #559 where we're unable to use `R.colors.primary()` in our swift projects, as the function is not available for WatchOS targets.

I've modified the color generators to output colors for WatchOS as follows:

```
#if os(watchOS)
    /// `UIColor(named: "primary", bundle: ..., traitCollection: ...)`
    @available(watchOSApplicationExtension 4.0, *)
    static func primary(compatibleWith traitCollection: Any? = nil) -> UIKit.UIColor? {
      return UIKit.UIColor(named: R.color.primary.name)
    }
#endif
```

I'm using `traitCollection: Any?` parameter as I need to pass a parameter, otherwise Xcode will take the function to be a redefinition of the resource, in this case `R.colors.primary`. I had to pass in Any, as UITraitCollection is not available in watchOS.

I also extracted the color functions into `fileprivate` functions as they were being used twice in the same file.