### PR TITLE
Escape parameterised strings with inner quotes.

### DIFF
--- a/Sources/RswiftCore/Generators/StringsStructGenerator.swift
+++ b/Sources/RswiftCore/Generators/StringsStructGenerator.swift
@@ -303,7 +303,7 @@ struct StringsStructGenerator: ExternalOnlyStructGenerator {
         }
 
         guard let (locale, bundle) = localeBundle(tableName: "\(values.tableName)", preferredLanguages: preferredLanguages) else {
-          return "\(values.key)"
+          return "\(values.key.escapedStringLiteral)"
         }
 
         let format = \(values.swiftCode(bundle: "bundle"))


### PR DESCRIPTION
When having a parameterised string with inner quotes in the key:
```swift
"Parameterised string with \"inner quotes\"" = "Parameterised %@ string with \"inner quotes\"";
```
`StringStructGenerator.stringFunctionParams(for:at:)` generates an unescaped string in the second `guard` statement:
```swift
static func parameterisedStringWithInnerQuotes(_ value1: String, preferredLanguages: [String]? = nil) -> String {
  guard let preferredLanguages = preferredLanguages else {
    let format = NSLocalizedString("Parameterised string with \"inner quotes\"", bundle: hostingBundle, comment: "")
    return String(format: format, locale: applicationLocale, value1)
  }

  guard let (locale, bundle) = localeBundle(tableName: "Localizable", preferredLanguages: preferredLanguages) else {
    return "Parameterised string with "inner quotes""
  }

  let format = NSLocalizedString("Parameterised string with \"inner quotes\"", bundle: bundle, comment: "")
  return String(format: format, locale: locale, value1)
}
```

This fix handles that case.

This also fixes #666.