### PR TITLE
Fix for Named Asset Sort Issues

### DIFF
--- a/Sources/RswiftCore/ResourceTypes/NameCatalog.swift
+++ b/Sources/RswiftCore/ResourceTypes/NameCatalog.swift
@@ -18,6 +18,6 @@ struct NameCatalog: Hashable, Comparable {
   }
 
   static func < (lhs: NameCatalog, rhs: NameCatalog) -> Bool {
-    lhs.name < lhs.name
+    lhs.name < rhs.name
   }
 }


### PR DESCRIPTION
## Description

Addresses #678 

Named resources from the asset catalog (such as images or colors) were not properly being sorted in a stable way and re-generated `R.generated.swift` would have alternating sortings for some subset of assets.

In a recent custom comparison added to the new `NameCatalog`, `lhs` was referenced twice instead of compared properly against `rhs`. This PR fixes that and compares `lhs.name` to `rhs.name`.