### PR TITLE
Support custom symbol image sets

### DIFF
--- a/Sources/RswiftCore/ResourceTypes/AssetFolder.swift
+++ b/Sources/RswiftCore/ResourceTypes/AssetFolder.swift
@@ -10,7 +10,7 @@
 import Foundation
 
 // Note: "appiconset" is not loadable by default, so it's not included here
-private let imageExtensions: Set<String> = ["launchimage", "imageset", "imagestack"]
+private let imageExtensions: Set<String> = ["launchimage", "imageset", "imagestack", "symbolset"]
 
 private let colorExtensions: Set<String> = ["colorset"]
 


### PR DESCRIPTION
This patch adds support for custom symbol images [Apple Documentation - Creating Custom Symbol Images for Your App](https://developer.apple.com/documentation/uikit/uiimage/creating_custom_symbol_images_for_your_app)

Closes issue #685