### PR TITLE
Native M1 build with Fat binaries

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -7,7 +7,7 @@ on:
     branches: '*'
 
 env:
-  DEVELOPER_DIR: /Applications/Xcode_11.4.app/Contents/Developer
+  DEVELOPER_DIR: /Applications/Xcode_12.4.app/Contents/Developer
 
 jobs:
   unit-tests:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,11 +35,7 @@ jobs:
 
     - name: Build fat binary
       run: |
-        swift build -v -c release -Xswiftc "-target" -Xswiftc "arm64-apple-macos11"
-        mv .build/release/rswift .build/release/rswift-arm64
-        swift build -v -c release -Xswiftc "-target" -Xswiftc "x86_64-apple-macos11"
-        mv .build/release/rswift .build/release/rswift-x86_64
-        lipo -create .build/release/rswift-arm64 .build/release/rswift-x86_64 -output .build/release/rswift
+        swift build -c release --arch x86_64 --arch arm64
 
     - name: Import Signing Certificates
       uses: apple-actions/import-codesign-certs@v1
@@ -48,15 +44,15 @@ jobs:
         p12-password: ${{ secrets.APPLE_CERTS_PASSWORD }}
     - name: Code Sign
       run: |
-        codesign --force --options runtime --sign 'Developer ID Application: Mathijs Kadijk (5Z49PA849J)' .build/release/rswift
+        codesign --force --options runtime --sign 'Developer ID Application: Mathijs Kadijk (5Z49PA849J)' .build/apple/Products/Release/rswift
     - name: Store build artifact
       uses: actions/upload-artifact@v1
       with:
         name: rswift-${{ github.event.release.tag_name }}
-        path: .build/release/rswift
+        path: .build/apple/Products/Release/rswift
 
     - name: Archive ZIP
-      run: zip --junk-paths ${{ runner.temp }}/rswift-${{ github.event.release.tag_name }}.zip .build/release/rswift License
+      run: zip --junk-paths ${{ runner.temp }}/rswift-${{ github.event.release.tag_name }}.zip .build/apple/Products/Release/rswift License
     - name: Notarize ZIP
       run: |
         sh notarize.sh
@@ -87,7 +83,7 @@ jobs:
     - name: Archive PKG
       run: |
         mkdir -p $PKG_ROOT/$BINARY_ROOT
-        cp .build/release/rswift $PKG_ROOT/$BINARY_ROOT
+        cp .build/apple/Products/Release/rswift $PKG_ROOT/$BINARY_ROOT
         pkgbuild --root $PKG_ROOT --identifier "nl.mathijskadijk.rswift" --version $TAG_NAME --install-location "/" --sign "Developer ID Installer: Mathijs Kadijk (5Z49PA849J)" $FILENAME
       env:
         TAG_NAME: ${{ github.event.release.tag_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
     types: created
 
 env:
-  DEVELOPER_DIR: /Applications/Xcode_11.4.app/Contents/Developer
+  DEVELOPER_DIR: /Applications/Xcode_12.4.app/Contents/Developer
 
 jobs:
   release-build:
@@ -33,8 +33,14 @@ jobs:
         asset_name: rswift-${{ github.event.release.tag_name }}-source.tar.gz
         asset_content_type: application/tar+gzip
 
-    - name: Build
-      run: swift build -v -c release
+    - name: Build fat binary
+      run: |
+        swift build -v -c release -Xswiftc "-target" -Xswiftc "arm64-apple-macos11"
+        mv .build/release/rswift .build/release/rswift-arm64
+        swift build -v -c release -Xswiftc "-target" -Xswiftc "x86_64-apple-macos11"
+        mv .build/release/rswift .build/release/rswift-x86_64
+        lipo -create .build/release/rswift-arm64 .build-x86_64/release/rswift-x86_64 -create .build/release/rswift
+
     - name: Import Signing Certificates
       uses: apple-actions/import-codesign-certs@v1
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
         mv .build/release/rswift .build/release/rswift-arm64
         swift build -v -c release -Xswiftc "-target" -Xswiftc "x86_64-apple-macos11"
         mv .build/release/rswift .build/release/rswift-x86_64
-        lipo -create .build/release/rswift-arm64 .build-x86_64/release/rswift-x86_64 -create .build/release/rswift
+        lipo -create .build/release/rswift-arm64 .build/release/rswift-x86_64 -output .build/release/rswift
 
     - name: Import Signing Certificates
       uses: apple-actions/import-codesign-certs@v1


### PR DESCRIPTION
Fixes https://github.com/mac-cain13/R.swift/issues/691

Builds a fat binary for x86_64 and arm64