### PR TITLE
Bundle resources support

### DIFF
--- a/Sources/RswiftCore/Generators/AccessibilityIdentifierStructGenerator.swift
+++ b/Sources/RswiftCore/Generators/AccessibilityIdentifierStructGenerator.swift
@@ -24,7 +24,7 @@ struct AccessibilityIdentifierStructGenerator: ExternalOnlyStructGenerator {
     accessibilityIdentifierContainers = nibs + storyboards
   }
 
-  func generatedStruct(at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier, bundle: String) -> Struct {
+  func generatedStruct(at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier, bundle: BundleExpression) -> Struct {
     let structName: SwiftIdentifier = "id"
     let qualifiedName = prefix + structName
     let structsForMergedContainers = accessibilityIdentifierContainers

--- a/Sources/RswiftCore/Generators/AccessibilityIdentifierStructGenerator.swift
+++ b/Sources/RswiftCore/Generators/AccessibilityIdentifierStructGenerator.swift
@@ -24,7 +24,7 @@ struct AccessibilityIdentifierStructGenerator: ExternalOnlyStructGenerator {
     accessibilityIdentifierContainers = nibs + storyboards
   }
 
-  func generatedStruct(at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier) -> Struct {
+  func generatedStruct(at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier, bundle: String) -> Struct {
     let structName: SwiftIdentifier = "id"
     let qualifiedName = prefix + structName
     let structsForMergedContainers = accessibilityIdentifierContainers

--- a/Sources/RswiftCore/Generators/AggregatedStructGenerator.swift
+++ b/Sources/RswiftCore/Generators/AggregatedStructGenerator.swift
@@ -16,7 +16,7 @@ class AggregatedStructGenerator: StructGenerator {
     self.subgenerators = subgenerators
   }
 
-  func generatedStructs(at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier, bundle: String) -> StructGenerator.Result {
+  func generatedStructs(at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier, bundle: BundleExpression) -> StructGenerator.Result {
     let structName: SwiftIdentifier = "R"
     let qualifiedName = structName
     let internalStructName: SwiftIdentifier = "_R"

--- a/Sources/RswiftCore/Generators/AggregatedStructGenerator.swift
+++ b/Sources/RswiftCore/Generators/AggregatedStructGenerator.swift
@@ -16,14 +16,14 @@ class AggregatedStructGenerator: StructGenerator {
     self.subgenerators = subgenerators
   }
 
-  func generatedStructs(at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier) -> StructGenerator.Result {
+  func generatedStructs(at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier, bundle: String) -> StructGenerator.Result {
     let structName: SwiftIdentifier = "R"
     let qualifiedName = structName
     let internalStructName: SwiftIdentifier = "_R"
 
     let collectedResult = subgenerators
       .compactMap {
-        let result = $0.generatedStructs(at: externalAccessLevel, prefix: qualifiedName)
+        let result = $0.generatedStructs(at: externalAccessLevel, prefix: qualifiedName, bundle: bundle)
         if result.externalStruct.isEmpty { return nil }
         if let internalStruct = result.internalStruct, internalStruct.isEmpty { return nil }
 

--- a/Sources/RswiftCore/Generators/BundleStructGenerator.swift
+++ b/Sources/RswiftCore/Generators/BundleStructGenerator.swift
@@ -1,0 +1,96 @@
+//
+//  NibStructGenerator.swift
+//  R.swift
+//
+//  Created by Ivan Zezyulya on 18-05-21.
+//  From: https://github.com/mac-cain13/R.swift
+//  License: MIT License
+//
+
+import Foundation
+
+struct BundleStructGenerator: ExternalOnlyStructGenerator {
+  struct BundleInfo {
+    let bundle: Bundle
+    let structGenerators: [StructGenerator]
+  }
+  
+  private let bundleInfos: [BundleInfo]
+
+  init(bundleInfos: [BundleInfo]) {
+    self.bundleInfos = bundleInfos
+  }
+
+  func generatedStruct(at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier, bundle: String) -> Struct {
+    let structName: SwiftIdentifier = "bundle"
+    let qualifiedName = prefix + structName
+
+    let structs = bundleInfos.compactMap { bundleInfo -> Struct? in
+      return bundleStruct(info: bundleInfo, at: externalAccessLevel, prefix: qualifiedName)
+    }
+
+    return Struct(
+      availables: [],
+      comments: ["This `\(qualifiedName)` struct is generated, and contains static references to \(structs.count) bundles."],
+      accessModifier: externalAccessLevel,
+      type: Type(module: .host, name: structName),
+      implements: [],
+      typealiasses: [],
+      properties: [],
+      functions: [],
+      structs: structs,
+      classes: [],
+      os: []
+    )
+  }
+  
+  private func bundleStruct(info: BundleInfo, at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier) -> Struct? {
+    let bundle = info.bundle.bundleName
+    let structName = SwiftIdentifier(name: bundle)
+    let qualifiedName = prefix + structName
+    
+    let structs = info.structGenerators.compactMap { generator -> Struct? in
+      let resourceStructs = generator.generatedStructs(at: externalAccessLevel, prefix: qualifiedName, bundle: "\(qualifiedName).bundle")
+      return resourceStructs.externalStruct
+    }
+    .filter {
+      !$0.isEmpty
+    }
+
+    return Struct(
+      availables: [],
+      comments: ["This `\(qualifiedName)` struct is generated, and contains static references to \(structs.count) resource groups."],
+      accessModifier: externalAccessLevel,
+      type: Type(module: .host, name: structName),
+      implements: [],
+      typealiasses: [],
+      properties: [bundleURLLet(bundle: bundle), bundleLet(bundle: bundle)],
+      functions: [],
+      structs: structs,
+      classes: [],
+      os: []
+    )
+  }
+  
+  private func bundleURLLet(bundle: String) -> Let {
+    return Let(
+      comments: [],
+      accessModifier: .publicLevel,
+      isStatic: true,
+      name: SwiftIdentifier(name: "bundleURL"),
+      typeDefinition: .inferred(Type._URL),
+      value: "R.hostingBundle.bundleURL.appendingPathComponent(\"\(bundle).bundle\")"
+    )
+  }
+
+  private func bundleLet(bundle: String) -> Let {
+    return Let(
+      comments: [],
+      accessModifier: .publicLevel,
+      isStatic: true,
+      name: SwiftIdentifier(name: "bundle"),
+      typeDefinition: .inferred(Type._Bundle),
+      value: "Bundle(url: bundleURL)!"
+    )
+  }
+}

--- a/Sources/RswiftCore/Generators/BundleStructGenerator.swift
+++ b/Sources/RswiftCore/Generators/BundleStructGenerator.swift
@@ -90,7 +90,7 @@ struct BundleStructGenerator: ExternalOnlyStructGenerator {
       isStatic: true,
       name: SwiftIdentifier(name: "bundle"),
       typeDefinition: .inferred(Type._Bundle),
-      value: "Bundle(url: bundleURL)!"
+      value: "Bundle(url: bundleURL)"
     )
   }
 }

--- a/Sources/RswiftCore/Generators/BundleStructGenerator.swift
+++ b/Sources/RswiftCore/Generators/BundleStructGenerator.swift
@@ -64,7 +64,7 @@ struct BundleStructGenerator: ExternalOnlyStructGenerator {
       type: Type(module: .host, name: structName),
       implements: [],
       typealiasses: [],
-      properties: [bundleURLLet(bundle: bundle), bundleLet(bundle: bundle)],
+      properties: [bundleURLLet(at: externalAccessLevel, bundle: bundle), bundleLet(at: externalAccessLevel, bundle: bundle)],
       functions: [],
       structs: structs,
       classes: [],
@@ -72,10 +72,10 @@ struct BundleStructGenerator: ExternalOnlyStructGenerator {
     )
   }
   
-  private func bundleURLLet(bundle: String) -> Let {
+  private func bundleURLLet(at externalAccessLevel: AccessLevel, bundle: String) -> Let {
     return Let(
       comments: [],
-      accessModifier: .publicLevel,
+      accessModifier: externalAccessLevel,
       isStatic: true,
       name: SwiftIdentifier(name: "bundleURL"),
       typeDefinition: .inferred(Type._URL),
@@ -83,10 +83,10 @@ struct BundleStructGenerator: ExternalOnlyStructGenerator {
     )
   }
 
-  private func bundleLet(bundle: String) -> Let {
+  private func bundleLet(at externalAccessLevel: AccessLevel, bundle: String) -> Let {
     return Let(
       comments: [],
-      accessModifier: .publicLevel,
+      accessModifier: externalAccessLevel,
       isStatic: true,
       name: SwiftIdentifier(name: "bundle"),
       typeDefinition: .inferred(Type._Bundle),

--- a/Sources/RswiftCore/Generators/BundleStructGenerator.swift
+++ b/Sources/RswiftCore/Generators/BundleStructGenerator.swift
@@ -1,5 +1,5 @@
 //
-//  NibStructGenerator.swift
+//  BundleStructGenerator.swift
 //  R.swift
 //
 //  Created by Ivan Zezyulya on 18-05-21.

--- a/Sources/RswiftCore/Generators/ColorStructGenerator.swift
+++ b/Sources/RswiftCore/Generators/ColorStructGenerator.swift
@@ -57,8 +57,13 @@ struct ColorStructGenerator: ExternalOnlyStructGenerator {
       implements: [],
       typealiasses: [],
       properties: colorLets,
-      functions: groupedColors.uniques.map { [ generateColorFunction(for: $0, at: externalAccessLevel, prefix: qualifiedName),
-                                               generateWatchOSColorFunction(for: $0, at: externalAccessLevel, prefix: qualifiedName)] }.flatMap { $0 },
+      functions: groupedColors.uniques.map { name -> [Function] in
+        var functions = [ generateColorFunction(for: name, at: externalAccessLevel, prefix: qualifiedName)]
+        if case .hostingBundle = bundle {
+          functions.append(generateWatchOSColorFunction(for: name, at: externalAccessLevel, prefix: qualifiedName))
+        }
+        return functions
+      }.flatMap { $0 },
       structs: structs,
       classes: [],
       os: []
@@ -101,7 +106,7 @@ private extension NamespacedAssetSubfolder {
           value: "Rswift.ColorResource(bundle: \(bundle), name: \"\(colorPath)\(name)\")"
         )
     }
-
+    
     return Struct(
       availables: [],
       comments: ["This `\(qualifiedName)` struct is generated, and contains static references to \(colorLets.count) colors."],
@@ -110,8 +115,13 @@ private extension NamespacedAssetSubfolder {
       implements: [],
       typealiasses: [],
       properties: colorLets,
-      functions: groupedFunctions.uniques.map { [ generateColorFunction(for: $0, at: externalAccessLevel, prefix: qualifiedName),
-                                                  generateWatchOSColorFunction(for: $0, at: externalAccessLevel, prefix: qualifiedName)] }.flatMap { $0 },
+      functions: groupedFunctions.uniques.map { name -> [Function] in
+        var functions = [ generateColorFunction(for: name, at: externalAccessLevel, prefix: qualifiedName)]
+        if case .hostingBundle = bundle {
+          functions.append(generateWatchOSColorFunction(for: name, at: externalAccessLevel, prefix: qualifiedName))
+        }
+        return functions
+      }.flatMap { $0 },
       structs: structs,
       classes: [],
       os: []

--- a/Sources/RswiftCore/Generators/ColorStructGenerator.swift
+++ b/Sources/RswiftCore/Generators/ColorStructGenerator.swift
@@ -16,7 +16,7 @@ struct ColorStructGenerator: ExternalOnlyStructGenerator {
     self.assetFolders = assetFolders
   }
 
-  func generatedStruct(at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier, bundle: String) -> Struct {
+  func generatedStruct(at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier, bundle: BundleExpression) -> Struct {
     let structName: SwiftIdentifier = "color"
     let qualifiedName = prefix + structName
     let assetFolderColorNames = assetFolders
@@ -69,7 +69,7 @@ struct ColorStructGenerator: ExternalOnlyStructGenerator {
 }
 
 private extension NamespacedAssetSubfolder {
-  func generatedColorStruct(at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier, bundle: String) -> Struct {
+  func generatedColorStruct(at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier, bundle: BundleExpression) -> Struct {
     let allFunctions = colorAssets
     let groupedFunctions = allFunctions.grouped(bySwiftIdentifier: { $0 })
 

--- a/Sources/RswiftCore/Generators/ColorStructGenerator.swift
+++ b/Sources/RswiftCore/Generators/ColorStructGenerator.swift
@@ -16,7 +16,7 @@ struct ColorStructGenerator: ExternalOnlyStructGenerator {
     self.assetFolders = assetFolders
   }
 
-  func generatedStruct(at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier) -> Struct {
+  func generatedStruct(at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier, bundle: String) -> Struct {
     let structName: SwiftIdentifier = "color"
     let qualifiedName = prefix + structName
     let assetFolderColorNames = assetFolders
@@ -33,7 +33,7 @@ struct ColorStructGenerator: ExternalOnlyStructGenerator {
     assetSubfolders.printWarningsForDuplicates()
 
     let structs = assetSubfolders.folders
-      .map { $0.generatedColorStruct(at: externalAccessLevel, prefix: qualifiedName) }
+      .map { $0.generatedColorStruct(at: externalAccessLevel, prefix: qualifiedName, bundle: bundle) }
       .filter { !$0.isEmpty }
 
     let colorLets = groupedColors
@@ -45,7 +45,7 @@ struct ColorStructGenerator: ExternalOnlyStructGenerator {
           isStatic: true,
           name: SwiftIdentifier(name: name),
           typeDefinition: .inferred(Type.ColorResource),
-          value: "Rswift.ColorResource(bundle: R.hostingBundle, name: \"\(name)\")"
+          value: "Rswift.ColorResource(bundle: \(bundle), name: \"\(name)\")"
         )
     }
 
@@ -69,7 +69,7 @@ struct ColorStructGenerator: ExternalOnlyStructGenerator {
 }
 
 private extension NamespacedAssetSubfolder {
-  func generatedColorStruct(at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier) -> Struct {
+  func generatedColorStruct(at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier, bundle: String) -> Struct {
     let allFunctions = colorAssets
     let groupedFunctions = allFunctions.grouped(bySwiftIdentifier: { $0 })
 
@@ -86,7 +86,7 @@ private extension NamespacedAssetSubfolder {
     let structName = SwiftIdentifier(name: self.name)
     let qualifiedName = prefix + structName
     let structs = assetSubfolders.folders
-      .map { $0.generatedColorStruct(at: externalAccessLevel, prefix: qualifiedName) }
+      .map { $0.generatedColorStruct(at: externalAccessLevel, prefix: qualifiedName, bundle: bundle) }
       .filter { !$0.isEmpty }
 
     let colorLets = groupedFunctions
@@ -98,7 +98,7 @@ private extension NamespacedAssetSubfolder {
           isStatic: true,
           name: SwiftIdentifier(name: name),
           typeDefinition: .inferred(Type.ColorResource),
-          value: "Rswift.ColorResource(bundle: R.hostingBundle, name: \"\(colorPath)\(name)\")"
+          value: "Rswift.ColorResource(bundle: \(bundle), name: \"\(colorPath)\(name)\")"
         )
     }
 

--- a/Sources/RswiftCore/Generators/FontStructGenerator.swift
+++ b/Sources/RswiftCore/Generators/FontStructGenerator.swift
@@ -16,7 +16,7 @@ struct FontStructGenerator: ExternalOnlyStructGenerator {
     self.fonts = fonts
   }
 
-  func generatedStruct(at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier) -> Struct {
+  func generatedStruct(at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier, bundle: String) -> Struct {
     let structName: SwiftIdentifier = "font"
     let qualifiedName = prefix + structName
 

--- a/Sources/RswiftCore/Generators/FontStructGenerator.swift
+++ b/Sources/RswiftCore/Generators/FontStructGenerator.swift
@@ -16,7 +16,7 @@ struct FontStructGenerator: ExternalOnlyStructGenerator {
     self.fonts = fonts
   }
 
-  func generatedStruct(at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier, bundle: String) -> Struct {
+  func generatedStruct(at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier, bundle: BundleExpression) -> Struct {
     let structName: SwiftIdentifier = "font"
     let qualifiedName = prefix + structName
 

--- a/Sources/RswiftCore/Generators/ImageStructGenerator.swift
+++ b/Sources/RswiftCore/Generators/ImageStructGenerator.swift
@@ -18,7 +18,7 @@ struct ImageStructGenerator: ExternalOnlyStructGenerator {
     self.images = images
   }
 
-  func generatedStruct(at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier, bundle: String) -> Struct {
+  func generatedStruct(at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier, bundle: BundleExpression) -> Struct {
     let structName: SwiftIdentifier = "image"
     let qualifiedName = prefix + structName
     let assetFolderImageNames = assetFolders
@@ -101,7 +101,7 @@ struct ImageStructGenerator: ExternalOnlyStructGenerator {
 }
 
 private extension NamespacedAssetSubfolder {
-  func generatedImageStruct(at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier, bundle: String) -> Struct {
+  func generatedImageStruct(at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier, bundle: BundleExpression) -> Struct {
     let allFunctions = imageAssets
     let groupedFunctions = allFunctions.grouped(bySwiftIdentifier: { $0 })
 

--- a/Sources/RswiftCore/Generators/ImageStructGenerator.swift
+++ b/Sources/RswiftCore/Generators/ImageStructGenerator.swift
@@ -18,7 +18,7 @@ struct ImageStructGenerator: ExternalOnlyStructGenerator {
     self.images = images
   }
 
-  func generatedStruct(at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier) -> Struct {
+  func generatedStruct(at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier, bundle: String) -> Struct {
     let structName: SwiftIdentifier = "image"
     let qualifiedName = prefix + structName
     let assetFolderImageNames = assetFolders
@@ -42,7 +42,7 @@ struct ImageStructGenerator: ExternalOnlyStructGenerator {
     assetSubfolders.printWarningsForDuplicates()
 
     let structs = assetSubfolders.folders
-      .map { $0.generatedImageStruct(at: externalAccessLevel, prefix: qualifiedName) }
+      .map { $0.generatedImageStruct(at: externalAccessLevel, prefix: qualifiedName, bundle: bundle) }
       .filter { !$0.isEmpty }
 
     let imageLets = groupedFunctions
@@ -54,7 +54,7 @@ struct ImageStructGenerator: ExternalOnlyStructGenerator {
           isStatic: true,
           name: SwiftIdentifier(name: name),
           typeDefinition: .inferred(Type.ImageResource),
-          value: "Rswift.ImageResource(bundle: R.hostingBundle, name: \"\(name)\")"
+          value: "Rswift.ImageResource(bundle: \(bundle), name: \"\(name)\")"
         )
     }
 
@@ -101,7 +101,7 @@ struct ImageStructGenerator: ExternalOnlyStructGenerator {
 }
 
 private extension NamespacedAssetSubfolder {
-  func generatedImageStruct(at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier) -> Struct {
+  func generatedImageStruct(at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier, bundle: String) -> Struct {
     let allFunctions = imageAssets
     let groupedFunctions = allFunctions.grouped(bySwiftIdentifier: { $0 })
 
@@ -118,7 +118,7 @@ private extension NamespacedAssetSubfolder {
     let structName = SwiftIdentifier(name: self.name)
     let qualifiedName = prefix + structName
     let structs = assetSubfolders.folders
-      .map { $0.generatedImageStruct(at: externalAccessLevel, prefix: qualifiedName) }
+      .map { $0.generatedImageStruct(at: externalAccessLevel, prefix: qualifiedName, bundle: bundle) }
       .filter { !$0.isEmpty }
 
     let imageLets = groupedFunctions
@@ -130,7 +130,7 @@ private extension NamespacedAssetSubfolder {
           isStatic: true,
           name: SwiftIdentifier(name: name),
           typeDefinition: .inferred(Type.ImageResource),
-          value: "Rswift.ImageResource(bundle: R.hostingBundle, name: \"\(imagePath)\(name)\")"
+          value: "Rswift.ImageResource(bundle: \(bundle), name: \"\(imagePath)\(name)\")"
         )
     }
 

--- a/Sources/RswiftCore/Generators/NibStructGenerator.swift
+++ b/Sources/RswiftCore/Generators/NibStructGenerator.swift
@@ -149,7 +149,7 @@ struct NibStructGenerator: StructGenerator {
       accessModifier: externalAccessLevel,
       isStatic: false,
       name: "bundle",
-      typeDefinition: .inferred(Type._Bundle),
+      typeDefinition: .specified(Type._Bundle.asOptional()),
       value: bundle.description
     )
 

--- a/Sources/RswiftCore/Generators/NibStructGenerator.swift
+++ b/Sources/RswiftCore/Generators/NibStructGenerator.swift
@@ -44,7 +44,7 @@ struct NibStructGenerator: StructGenerator {
     self.nibs = nibs
   }
 
-  func generatedStructs(at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier, bundle: String) -> StructGenerator.Result {
+  func generatedStructs(at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier, bundle: BundleExpression) -> StructGenerator.Result {
     let structName: SwiftIdentifier = "nib"
     let qualifiedName = prefix + structName
     let groupedNibs = nibs.grouped(bySwiftIdentifier: { $0.name })
@@ -143,14 +143,14 @@ struct NibStructGenerator: StructGenerator {
     )
   }
 
-  private func nibStruct(for nib: Nib, at externalAccessLevel: AccessLevel, bundle: String) -> Struct {
+  private func nibStruct(for nib: Nib, at externalAccessLevel: AccessLevel, bundle: BundleExpression) -> Struct {
     let bundleLet = Let(
       comments: [],
       accessModifier: externalAccessLevel,
       isStatic: false,
       name: "bundle",
       typeDefinition: .inferred(Type._Bundle),
-      value: bundle
+      value: bundle.description
     )
 
     let nameVar = Let(

--- a/Sources/RswiftCore/Generators/PropertyListGenerator.swift
+++ b/Sources/RswiftCore/Generators/PropertyListGenerator.swift
@@ -20,7 +20,7 @@ struct PropertyListGenerator: ExternalOnlyStructGenerator {
     self.toplevelKeysWhitelist = toplevelKeysWhitelist
   }
 
-  func generatedStruct(at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier, bundle: String) -> Struct {
+  func generatedStruct(at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier, bundle: BundleExpression) -> Struct {
     guard let plist = plists.first else { return .empty }
 
     guard plists.all(where: { $0.url == plist.url }) else {

--- a/Sources/RswiftCore/Generators/PropertyListGenerator.swift
+++ b/Sources/RswiftCore/Generators/PropertyListGenerator.swift
@@ -20,7 +20,7 @@ struct PropertyListGenerator: ExternalOnlyStructGenerator {
     self.toplevelKeysWhitelist = toplevelKeysWhitelist
   }
 
-  func generatedStruct(at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier) -> Struct {
+  func generatedStruct(at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier, bundle: String) -> Struct {
     guard let plist = plists.first else { return .empty }
 
     guard plists.all(where: { $0.url == plist.url }) else {

--- a/Sources/RswiftCore/Generators/ResourceFileStructGenerator.swift
+++ b/Sources/RswiftCore/Generators/ResourceFileStructGenerator.swift
@@ -16,7 +16,7 @@ struct ResourceFileStructGenerator: ExternalOnlyStructGenerator {
     self.resourceFiles = resourceFiles
   }
 
-  func generatedStruct(at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier, bundle: String) -> Struct {
+  func generatedStruct(at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier, bundle: BundleExpression) -> Struct {
     let structName: SwiftIdentifier = "file"
     let qualifiedName = prefix + structName
     let localized = resourceFiles.grouped(by: { $0.fullname })
@@ -42,7 +42,7 @@ struct ResourceFileStructGenerator: ExternalOnlyStructGenerator {
     )
   }
 
-  private func propertiesFromResourceFiles(resourceFiles: [ResourceFile], at externalAccessLevel: AccessLevel, bundle: String) -> [Let] {
+  private func propertiesFromResourceFiles(resourceFiles: [ResourceFile], at externalAccessLevel: AccessLevel, bundle: BundleExpression) -> [Let] {
 
     return resourceFiles
       .map {
@@ -78,7 +78,7 @@ struct ResourceFileStructGenerator: ExternalOnlyStructGenerator {
             ],
             doesThrow: false,
             returnType: Type._URL.asOptional(),
-            body: "let fileResource = \(SwiftIdentifier(name: fullname))\nreturn fileResource.bundle.url(forResource: fileResource)",
+            body: "let fileResource = \(SwiftIdentifier(name: fullname))\nreturn fileResource.bundle?.url(forResource: fileResource)",
             os: []
           )
         ]

--- a/Sources/RswiftCore/Generators/ResourceFileStructGenerator.swift
+++ b/Sources/RswiftCore/Generators/ResourceFileStructGenerator.swift
@@ -16,7 +16,7 @@ struct ResourceFileStructGenerator: ExternalOnlyStructGenerator {
     self.resourceFiles = resourceFiles
   }
 
-  func generatedStruct(at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier) -> Struct {
+  func generatedStruct(at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier, bundle: String) -> Struct {
     let structName: SwiftIdentifier = "file"
     let qualifiedName = prefix + structName
     let localized = resourceFiles.grouped(by: { $0.fullname })
@@ -34,7 +34,7 @@ struct ResourceFileStructGenerator: ExternalOnlyStructGenerator {
       type: Type(module: .host, name: structName),
       implements: [],
       typealiasses: [],
-      properties: firstLocales.flatMap { propertiesFromResourceFiles(resourceFiles: $0.1, at: externalAccessLevel) },
+      properties: firstLocales.flatMap { propertiesFromResourceFiles(resourceFiles: $0.1, at: externalAccessLevel, bundle: bundle) },
       functions: firstLocales.flatMap { functionsFromResourceFiles(resourceFiles: $0.1, at: externalAccessLevel) },
       structs: [],
       classes: [],
@@ -42,7 +42,7 @@ struct ResourceFileStructGenerator: ExternalOnlyStructGenerator {
     )
   }
 
-  private func propertiesFromResourceFiles(resourceFiles: [ResourceFile], at externalAccessLevel: AccessLevel) -> [Let] {
+  private func propertiesFromResourceFiles(resourceFiles: [ResourceFile], at externalAccessLevel: AccessLevel, bundle: String) -> [Let] {
 
     return resourceFiles
       .map {
@@ -52,13 +52,13 @@ struct ResourceFileStructGenerator: ExternalOnlyStructGenerator {
           isStatic: true,
           name: SwiftIdentifier(name: $0.fullname),
           typeDefinition: .inferred(Type.FileResource),
-          value: "Rswift.FileResource(bundle: R.hostingBundle, name: \"\($0.filename)\", pathExtension: \"\($0.pathExtension)\")"
+          value: "Rswift.FileResource(bundle: \(bundle), name: \"\($0.filename)\", pathExtension: \"\($0.pathExtension)\")"
         )
     }
   }
 
   private func functionsFromResourceFiles(resourceFiles: [ResourceFile], at externalAccessLevel: AccessLevel) -> [Function] {
-
+    
     return resourceFiles
       .flatMap { resourceFile -> [Function] in
         let fullname = resourceFile.fullname
@@ -78,7 +78,7 @@ struct ResourceFileStructGenerator: ExternalOnlyStructGenerator {
             ],
             doesThrow: false,
             returnType: Type._URL.asOptional(),
-            body: "let fileResource = R.file.\(SwiftIdentifier(name: fullname))\nreturn fileResource.bundle.url(forResource: fileResource)",
+            body: "let fileResource = \(SwiftIdentifier(name: fullname))\nreturn fileResource.bundle.url(forResource: fileResource)",
             os: []
           )
         ]

--- a/Sources/RswiftCore/Generators/ReuseIdentifierGenerator.swift
+++ b/Sources/RswiftCore/Generators/ReuseIdentifierGenerator.swift
@@ -16,7 +16,7 @@ struct ReuseIdentifierStructGenerator: ExternalOnlyStructGenerator {
     self.reusables = reusables
   }
 
-  func generatedStruct(at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier, bundle: String) -> Struct {
+  func generatedStruct(at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier, bundle: BundleExpression) -> Struct {
     let structName: SwiftIdentifier = "reuseIdentifier"
     let qualifiedName = prefix + structName
     let deduplicatedReusables = reusables

--- a/Sources/RswiftCore/Generators/ReuseIdentifierGenerator.swift
+++ b/Sources/RswiftCore/Generators/ReuseIdentifierGenerator.swift
@@ -16,7 +16,7 @@ struct ReuseIdentifierStructGenerator: ExternalOnlyStructGenerator {
     self.reusables = reusables
   }
 
-  func generatedStruct(at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier) -> Struct {
+  func generatedStruct(at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier, bundle: String) -> Struct {
     let structName: SwiftIdentifier = "reuseIdentifier"
     let qualifiedName = prefix + structName
     let deduplicatedReusables = reusables

--- a/Sources/RswiftCore/Generators/SegueGenerator.swift
+++ b/Sources/RswiftCore/Generators/SegueGenerator.swift
@@ -26,7 +26,7 @@ struct SegueStructGenerator: ExternalOnlyStructGenerator {
     self.storyboards = storyboards
   }
 
-  func generatedStruct(at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier) -> Struct {
+  func generatedStruct(at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier, bundle: String) -> Struct {
     let structName: SwiftIdentifier = "segue"
     let qualifiedName = prefix + structName
 

--- a/Sources/RswiftCore/Generators/SegueGenerator.swift
+++ b/Sources/RswiftCore/Generators/SegueGenerator.swift
@@ -26,7 +26,7 @@ struct SegueStructGenerator: ExternalOnlyStructGenerator {
     self.storyboards = storyboards
   }
 
-  func generatedStruct(at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier, bundle: String) -> Struct {
+  func generatedStruct(at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier, bundle: BundleExpression) -> Struct {
     let structName: SwiftIdentifier = "segue"
     let qualifiedName = prefix + structName
 

--- a/Sources/RswiftCore/Generators/StoryboardGenerator.swift
+++ b/Sources/RswiftCore/Generators/StoryboardGenerator.swift
@@ -16,7 +16,7 @@ struct StoryboardStructGenerator: StructGenerator {
     self.storyboards = storyboards
   }
 
-  func generatedStructs(at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier, bundle: String) -> StructGenerator.Result {
+  func generatedStructs(at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier, bundle: BundleExpression) -> StructGenerator.Result {
     let structName: SwiftIdentifier = "storyboard"
     let qualifiedName = prefix + structName
     let groupedStoryboards = storyboards.grouped(bySwiftIdentifier: { $0.name })
@@ -90,7 +90,7 @@ struct StoryboardStructGenerator: StructGenerator {
     )
   }
 
-  private func storyboardStruct(for storyboard: Storyboard, at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier, bundle: String) -> Struct {
+  private func storyboardStruct(for storyboard: Storyboard, at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier, bundle: BundleExpression) -> Struct {
     let structName = SwiftIdentifier(name: storyboard.name)
     let qualifiedName = prefix + structName
 
@@ -99,7 +99,7 @@ struct StoryboardStructGenerator: StructGenerator {
     var functions: [Function] = []
     var properties: [Let] = [
       Let(comments: [], accessModifier: externalAccessLevel, isStatic: false, name: "name", typeDefinition: .inferred(Type._String), value: "\"\(storyboard.name)\""),
-      Let(comments: [], accessModifier: externalAccessLevel, isStatic: false, name: "bundle", typeDefinition: .inferred(Type._Bundle), value: bundle)
+      Let(comments: [], accessModifier: externalAccessLevel, isStatic: false, name: "bundle", typeDefinition: .inferred(Type._Bundle), value: bundle.description)
     ]
 
     // Initial view controller

--- a/Sources/RswiftCore/Generators/StoryboardGenerator.swift
+++ b/Sources/RswiftCore/Generators/StoryboardGenerator.swift
@@ -99,7 +99,7 @@ struct StoryboardStructGenerator: StructGenerator {
     var functions: [Function] = []
     var properties: [Let] = [
       Let(comments: [], accessModifier: externalAccessLevel, isStatic: false, name: "name", typeDefinition: .inferred(Type._String), value: "\"\(storyboard.name)\""),
-      Let(comments: [], accessModifier: externalAccessLevel, isStatic: false, name: "bundle", typeDefinition: .inferred(Type._Bundle), value: bundle.description)
+      Let(comments: [], accessModifier: externalAccessLevel, isStatic: false, name: "bundle", typeDefinition: .specified(Type._Bundle.asOptional()), value: bundle.description)
     ]
 
     // Initial view controller

--- a/Sources/RswiftCore/Generators/StringsStructGenerator.swift
+++ b/Sources/RswiftCore/Generators/StringsStructGenerator.swift
@@ -242,7 +242,7 @@ struct StringsStructGenerator: ExternalOnlyStructGenerator {
     case .hostingBundle:
       body = """
         guard let preferredLanguages = preferredLanguages else {
-          return \(values.swiftCode(bundle: bundle.description))
+          return \(values.swiftCode(bundle: "\(bundle)"))
         }
 
         guard let (_, foundBundle) = localeBundle(parentBundle: \(bundle), tableName: "\(values.tableName)", preferredLanguages: preferredLanguages) else {
@@ -315,7 +315,7 @@ struct StringsStructGenerator: ExternalOnlyStructGenerator {
     case .hostingBundle:
       body = """
         guard let preferredLanguages = preferredLanguages else {
-          let format = \(values.swiftCode(bundle: bundle.description))
+          let format = \(values.swiftCode(bundle: "\(bundle)"))
           return String(format: format, locale: applicationLocale, \(args))
         }
 

--- a/Sources/RswiftCore/Generators/StringsStructGenerator.swift
+++ b/Sources/RswiftCore/Generators/StringsStructGenerator.swift
@@ -402,14 +402,16 @@ fileprivate extension BundleExpression {
     switch self {
     case .hostingBundle:
       return """
-        guard let bundle = \(self) else {
-          return "\(values.key.escapedStringLiteral)"
-        }
+        let bundle = \(self)
+
 
       """
     case .customBundle:
       return """
-        let bundle = \(self)
+        guard let bundle = \(self) else {
+          return "\(values.key.escapedStringLiteral)"
+        }
+
 
       """
     }

--- a/Sources/RswiftCore/Generators/StringsStructGenerator.swift
+++ b/Sources/RswiftCore/Generators/StringsStructGenerator.swift
@@ -294,7 +294,7 @@ struct StringsStructGenerator: ExternalOnlyStructGenerator {
     
     body += """
       guard let preferredLanguages = preferredLanguages else {
-        let format = \(values.swiftCode(bundle: "\(bundle)"))
+        let format = \(values.swiftCode(bundle: "bundle"))
         return String(format: format, locale: applicationLocale, \(args))
       }
 

--- a/Sources/RswiftCore/Generators/StructGenerator.swift
+++ b/Sources/RswiftCore/Generators/StructGenerator.swift
@@ -12,17 +12,17 @@ import Foundation
 protocol StructGenerator {
   typealias Result = (externalStruct: Struct, internalStruct: Struct?)
 
-  func generatedStructs(at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier) -> Result
+  func generatedStructs(at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier, bundle: String) -> Result
 }
 
 protocol ExternalOnlyStructGenerator: StructGenerator {
-  func generatedStruct(at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier) -> Struct
+  func generatedStruct(at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier, bundle: String) -> Struct
 }
 
 extension ExternalOnlyStructGenerator {
-  func generatedStructs(at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier) -> StructGenerator.Result {
+  func generatedStructs(at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier, bundle: String) -> StructGenerator.Result {
     return (
-      generatedStruct(at: externalAccessLevel, prefix: prefix),
+      generatedStruct(at: externalAccessLevel, prefix: prefix, bundle: bundle),
       nil
     )
   }

--- a/Sources/RswiftCore/Generators/StructGenerator.swift
+++ b/Sources/RswiftCore/Generators/StructGenerator.swift
@@ -9,18 +9,32 @@
 
 import Foundation
 
+enum BundleExpression: CustomStringConvertible {
+  case hostingBundle
+  case customBundle(String)
+  
+  var description: String {
+    switch self {
+    case .hostingBundle:
+      return "R.hostingBundle"
+    case .customBundle(let value):
+      return value
+    }
+  }
+}
+
 protocol StructGenerator {
   typealias Result = (externalStruct: Struct, internalStruct: Struct?)
 
-  func generatedStructs(at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier, bundle: String) -> Result
+  func generatedStructs(at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier, bundle: BundleExpression) -> Result
 }
 
 protocol ExternalOnlyStructGenerator: StructGenerator {
-  func generatedStruct(at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier, bundle: String) -> Struct
+  func generatedStruct(at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier, bundle: BundleExpression) -> Struct
 }
 
 extension ExternalOnlyStructGenerator {
-  func generatedStructs(at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier, bundle: String) -> StructGenerator.Result {
+  func generatedStructs(at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier, bundle: BundleExpression) -> StructGenerator.Result {
     return (
       generatedStruct(at: externalAccessLevel, prefix: prefix, bundle: bundle),
       nil

--- a/Sources/RswiftCore/Generators/ValidatedStructGenerator.swift
+++ b/Sources/RswiftCore/Generators/ValidatedStructGenerator.swift
@@ -16,7 +16,7 @@ class ValidatedStructGenerator: StructGenerator {
     self.validationSubject = validationSubject
   }
 
-  func generatedStructs(at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier, bundle: String) -> StructGenerator.Result {
+  func generatedStructs(at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier, bundle: BundleExpression) -> StructGenerator.Result {
 
     let internalStruct = validationSubject.internalStruct?
       .addingChildStructValidationMethods(at: externalAccessLevel)

--- a/Sources/RswiftCore/Generators/ValidatedStructGenerator.swift
+++ b/Sources/RswiftCore/Generators/ValidatedStructGenerator.swift
@@ -16,7 +16,7 @@ class ValidatedStructGenerator: StructGenerator {
     self.validationSubject = validationSubject
   }
 
-  func generatedStructs(at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier) -> StructGenerator.Result {
+  func generatedStructs(at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier, bundle: String) -> StructGenerator.Result {
 
     let internalStruct = validationSubject.internalStruct?
       .addingChildStructValidationMethods(at: externalAccessLevel)

--- a/Sources/RswiftCore/ResourceTypes/Bundle.swift
+++ b/Sources/RswiftCore/ResourceTypes/Bundle.swift
@@ -1,0 +1,88 @@
+//
+//  Resources.swift
+//  R.swift
+//
+//  Created by Mathijs Kadijk on 11-06-21.
+//  From: https://github.com/mac-cain13/R.swift
+//  License: MIT License
+//
+
+import Foundation
+
+struct Bundle {
+  let bundleName: String
+  let resources: Resources
+
+  init(bundleUrl: URL, fileManager: FileManager) {
+    let bundleNameWithExtension = bundleUrl.lastPathComponent
+    bundleName = bundleNameWithExtension.replacingOccurrences(of: ".bundle", with: "")
+
+    let resourceURLs = Bundle.resourceURLs(for: bundleUrl, fileManager: fileManager)
+    resources = Resources(resourceURLs: resourceURLs, fileManager: fileManager)
+  }
+}
+
+private extension Bundle {
+  static func resourceURLs(for bundleUrl: URL, fileManager: FileManager) -> [URL] {
+    var resourceURLs = [URL]()
+    
+    let resourceDirectoryTypes: [WhiteListedExtensionsResourceType.Type] = [AssetFolder.self]
+    var resourceDirectorySuffixes = Set<String>()
+    resourceDirectoryTypes.forEach { resourceType in
+      resourceType.supportedExtensions.forEach { ext in
+        resourceDirectorySuffixes.insert(ext)
+      }
+    }
+
+    var prefixesToSkip = Set<String>()
+    prefixesToSkip.insert(".") // Ignore files like .DS_Store, etc.
+    
+    let isResourceDirectory: ((URL) -> Bool) = { url in
+      for suffix in resourceDirectorySuffixes {
+        if url.absoluteString.hasSuffix(suffix + "/") {
+          return true
+        }
+      }
+      return false
+    }
+    
+    let shouldSkip: ((URL) -> Bool) = { url in
+      let name = url.lastPathComponent
+      for prefix in prefixesToSkip {
+        if name.hasPrefix(prefix) {
+          return true
+        }
+      }
+      return false
+    }
+    
+    guard let enumerator = fileManager.enumerator(at: bundleUrl, includingPropertiesForKeys: nil) else {
+      return []
+    }
+
+    for case let itemURL as URL in enumerator {
+      if itemURL.isDirectory() {
+        if isResourceDirectory(itemURL) {
+          resourceURLs.append(itemURL)
+          enumerator.skipDescendents()
+        }
+      } else if !shouldSkip(itemURL) {
+        resourceURLs.append(itemURL)
+      }
+    }
+    
+    return resourceURLs
+  }
+}
+
+fileprivate extension URL {
+  func isDirectory() -> Bool {
+    do {
+      let value = try resourceValues(forKeys:[.isDirectoryKey])
+      return value.isDirectory ?? false
+    }
+    catch {
+      return false
+    }
+  }
+}

--- a/Sources/RswiftCore/ResourceTypes/Bundle.swift
+++ b/Sources/RswiftCore/ResourceTypes/Bundle.swift
@@ -1,8 +1,8 @@
 //
-//  Resources.swift
+//  Bundle.swift
 //  R.swift
 //
-//  Created by Mathijs Kadijk on 11-06-21.
+//  Created by Ivan Zezyulya on 11-06-21.
 //  From: https://github.com/mac-cain13/R.swift
 //  License: MIT License
 //

--- a/Sources/RswiftCore/ResourceTypes/Resources.swift
+++ b/Sources/RswiftCore/ResourceTypes/Resources.swift
@@ -14,7 +14,7 @@ enum ResourceParsingError: Error {
   case parsingFailed(String)
 }
 
-class Resources {
+struct Resources {
   let assetFolders: [AssetFolder]
   let images: [Image]
   let fonts: [Font]
@@ -56,7 +56,7 @@ class Resources {
       if let resourceFile = tryResourceParsing({ try ResourceFile(url: url) }) {
         if resourceFile.pathExtension == "bundle" {
           let bundle = Bundle(bundleUrl: url, fileManager: fileManager)
-          if bundle.resourceFiles.count != 0 {
+          if bundle.resources.resourceFiles.count != 0 {
             bundles.append(bundle)
           }
         } else {
@@ -79,70 +79,6 @@ class Resources {
   }
 }
 
-class Bundle: Resources {
-  let bundleName: String
-
-  init(bundleUrl: URL, fileManager: FileManager) {
-    let resourceURLs = Bundle.resourceURLs(for: bundleUrl, fileManager: fileManager)
-
-    let bundleNameWithExtension = bundleUrl.lastPathComponent
-    bundleName = bundleNameWithExtension.replacingOccurrences(of: ".bundle", with: "")
-
-    super.init(resourceURLs: resourceURLs, fileManager: fileManager)
-  }
-  
-  fileprivate static func resourceURLs(for bundleUrl: URL, fileManager: FileManager) -> [URL] {
-    var resourceURLs = [URL]()
-    
-    let resourceDirectoryTypes: [WhiteListedExtensionsResourceType.Type] = [AssetFolder.self]
-    var resourceDirectorySuffixes = Set<String>()
-    resourceDirectoryTypes.forEach { resourceType in
-      resourceType.supportedExtensions.forEach { ext in
-        resourceDirectorySuffixes.insert(ext)
-      }
-    }
-
-    var prefixesToSkip = Set<String>()
-    prefixesToSkip.insert(".") // Ignore files like .DS_Store, etc.
-    
-    let isResourceDirectory: ((URL) -> Bool) = { url in
-      for suffix in resourceDirectorySuffixes {
-        if url.absoluteString.hasSuffix(suffix + "/") {
-          return true
-        }
-      }
-      return false
-    }
-    
-    let shouldSkip: ((URL) -> Bool) = { url in
-      let name = url.lastPathComponent
-      for prefix in prefixesToSkip {
-        if name.hasPrefix(prefix) {
-          return true
-        }
-      }
-      return false
-    }
-    
-    guard let enumerator = fileManager.enumerator(at: bundleUrl, includingPropertiesForKeys: nil) else {
-      return []
-    }
-
-    for case let itemURL as URL in enumerator {
-      if itemURL.isDirectory() {
-        if isResourceDirectory(itemURL) {
-          resourceURLs.append(itemURL)
-          enumerator.skipDescendents()
-        }
-      } else if !shouldSkip(itemURL) {
-        resourceURLs.append(itemURL)
-      }
-    }
-    
-    return resourceURLs
-  }
-}
-
 private func tryResourceParsing<T>(_ parse: () throws -> T) -> T? {
   do {
     return try parse()
@@ -153,17 +89,5 @@ private func tryResourceParsing<T>(_ parse: () throws -> T) -> T? {
     return nil
   } catch {
     return nil
-  }
-}
-
-fileprivate extension URL {
-  func isDirectory() -> Bool {
-    do {
-      let value = try resourceValues(forKeys:[.isDirectoryKey])
-      return value.isDirectory ?? false
-    }
-    catch {
-      return false
-    }
   }
 }

--- a/Sources/RswiftCore/ResourceTypes/Resources.swift
+++ b/Sources/RswiftCore/ResourceTypes/Resources.swift
@@ -14,7 +14,7 @@ enum ResourceParsingError: Error {
   case parsingFailed(String)
 }
 
-struct Resources {
+class Resources {
   let assetFolders: [AssetFolder]
   let images: [Image]
   let fonts: [Font]
@@ -22,9 +22,10 @@ struct Resources {
   let storyboards: [Storyboard]
   let resourceFiles: [ResourceFile]
   let localizableStrings: [LocalizableStrings]
-    
-  let reusables: [Reusable]
+  let bundles: [Bundle]
 
+  let reusables: [Reusable]
+  
   init(resourceURLs: [URL], fileManager: FileManager) {
     
     var assetFolders = [AssetFolder]()
@@ -34,7 +35,8 @@ struct Resources {
     var storyboards = [Storyboard]()
     var resourceFiles = [ResourceFile]()
     var localizableStrings = [LocalizableStrings]()
-    
+    var bundles = [Bundle]()
+
     resourceURLs.forEach { url in
       if let nib = tryResourceParsing({ try Nib(url: url) }) {
         nibs.append(nib)
@@ -52,7 +54,14 @@ struct Resources {
 
       // All previous assets can also possibly be used as files
       if let resourceFile = tryResourceParsing({ try ResourceFile(url: url) }) {
-        resourceFiles.append(resourceFile)
+        if resourceFile.pathExtension == "bundle" {
+          let bundle = Bundle(bundleUrl: url, fileManager: fileManager)
+          if bundle.resourceFiles.count != 0 {
+            bundles.append(bundle)
+          }
+        } else {
+          resourceFiles.append(resourceFile)
+        }
       }
     }
     
@@ -63,9 +72,74 @@ struct Resources {
     self.storyboards = storyboards
     self.resourceFiles = resourceFiles
     self.localizableStrings = localizableStrings
+    self.bundles = bundles
     
     reusables = (nibs.map { $0 as ReusableContainer } + storyboards.map { $0 as ReusableContainer })
       .flatMap { $0.reusables }
+  }
+}
+
+class Bundle: Resources {
+  let bundleName: String
+
+  init(bundleUrl: URL, fileManager: FileManager) {
+    let resourceURLs = Bundle.resourceURLs(for: bundleUrl, fileManager: fileManager)
+
+    let bundleNameWithExtension = bundleUrl.lastPathComponent
+    bundleName = bundleNameWithExtension.replacingOccurrences(of: ".bundle", with: "")
+
+    super.init(resourceURLs: resourceURLs, fileManager: fileManager)
+  }
+  
+  fileprivate static func resourceURLs(for bundleUrl: URL, fileManager: FileManager) -> [URL] {
+    var resourceURLs = [URL]()
+    
+    let resourceDirectoryTypes: [WhiteListedExtensionsResourceType.Type] = [AssetFolder.self]
+    var resourceDirectorySuffixes = Set<String>()
+    resourceDirectoryTypes.forEach { resourceType in
+      resourceType.supportedExtensions.forEach { ext in
+        resourceDirectorySuffixes.insert(ext)
+      }
+    }
+
+    var prefixesToSkip = Set<String>()
+    prefixesToSkip.insert(".") // Ignore files like .DS_Store, etc.
+    
+    let isResourceDirectory: ((URL) -> Bool) = { url in
+      for suffix in resourceDirectorySuffixes {
+        if url.absoluteString.hasSuffix(suffix + "/") {
+          return true
+        }
+      }
+      return false
+    }
+    
+    let shouldSkip: ((URL) -> Bool) = { url in
+      let name = url.lastPathComponent
+      for prefix in prefixesToSkip {
+        if name.hasPrefix(prefix) {
+          return true
+        }
+      }
+      return false
+    }
+    
+    guard let enumerator = fileManager.enumerator(at: bundleUrl, includingPropertiesForKeys: nil) else {
+      return []
+    }
+
+    for case let itemURL as URL in enumerator {
+      if itemURL.isDirectory() {
+        if isResourceDirectory(itemURL) {
+          resourceURLs.append(itemURL)
+          enumerator.skipDescendents()
+        }
+      } else if !shouldSkip(itemURL) {
+        resourceURLs.append(itemURL)
+      }
+    }
+    
+    return resourceURLs
   }
 }
 
@@ -79,5 +153,17 @@ private func tryResourceParsing<T>(_ parse: () throws -> T) -> T? {
     return nil
   } catch {
     return nil
+  }
+}
+
+fileprivate extension URL {
+  func isDirectory() -> Bool {
+    do {
+      let value = try resourceValues(forKeys:[.isDirectoryKey])
+      return value.isDirectory ?? false
+    }
+    catch {
+      return false
+    }
   }
 }

--- a/Sources/RswiftCore/RswiftCore.swift
+++ b/Sources/RswiftCore/RswiftCore.swift
@@ -57,7 +57,7 @@ public struct RswiftCore {
         let supportedGenerators: [Generator] = [.image, .string, .color, .file]
         let availableGenerators = Array(Set(supportedGenerators).intersection(Set(callInformation.generators)))
         for bundle in resources.bundles {
-          let bundleStructGenerators = makeStructGenerators(availableGenerators: availableGenerators, resources: bundle, developmentLanguage: xcodeproj.developmentLanguage)
+          let bundleStructGenerators = makeStructGenerators(availableGenerators: availableGenerators, resources: bundle.resources, developmentLanguage: xcodeproj.developmentLanguage)
           let bundleInfo = BundleStructGenerator.BundleInfo(bundle: bundle, structGenerators: bundleStructGenerators)
           bundleInfos.append(bundleInfo)
         }

--- a/Sources/RswiftCore/RswiftCore.swift
+++ b/Sources/RswiftCore/RswiftCore.swift
@@ -54,7 +54,7 @@ public struct RswiftCore {
       if callInformation.generators.contains(.bundle) {
         var bundleInfos: [BundleStructGenerator.BundleInfo] = []
         // Enhance this list after testing:
-        let supportedGenerators: [Generator] = [.image, .string, .color, .file, .font]
+        let supportedGenerators: [Generator] = [.image, .string, .color, .file]
         let availableGenerators = Array(Set(supportedGenerators).intersection(Set(callInformation.generators)))
         for bundle in resources.bundles {
           let bundleStructGenerators = makeStructGenerators(availableGenerators: availableGenerators, resources: bundle, developmentLanguage: xcodeproj.developmentLanguage)

--- a/Sources/RswiftCore/RswiftCore.swift
+++ b/Sources/RswiftCore/RswiftCore.swift
@@ -147,10 +147,10 @@ public struct RswiftCore {
 
   private func generateRegularFileContents(resources: Resources, generators: [StructGenerator]) -> String {
     let aggregatedResult = AggregatedStructGenerator(subgenerators: generators)
-      .generatedStructs(at: callInformation.accessLevel, prefix: "", bundle: "R.hostingBundle")
+      .generatedStructs(at: callInformation.accessLevel, prefix: "", bundle: .hostingBundle)
 
     let (externalStructWithoutProperties, internalStruct) = ValidatedStructGenerator(validationSubject: aggregatedResult)
-      .generatedStructs(at: callInformation.accessLevel, prefix: "", bundle: "R.hostingBundle")
+      .generatedStructs(at: callInformation.accessLevel, prefix: "", bundle: .hostingBundle)
 
     let externalStruct = externalStructWithoutProperties.addingInternalProperties(forBundleIdentifier: callInformation.bundleIdentifier)
 
@@ -173,7 +173,7 @@ public struct RswiftCore {
 
   private func generateUITestFileContents(resources: Resources, generators: [StructGenerator]) -> String {
     let (externalStruct, _) =  AggregatedStructGenerator(subgenerators: generators)
-      .generatedStructs(at: callInformation.accessLevel, prefix: "", bundle: "R.hostingBundle")
+      .generatedStructs(at: callInformation.accessLevel, prefix: "", bundle: .hostingBundle)
 
     let codeConvertibles: [SwiftCodeConverible?] = [
       HeaderPrinter(),


### PR DESCRIPTION
Hi!

Please review/check this implementation of bundle resources support.

Only following types of resources are enabled for now: `image`, `string`, `color`, `file`, I've tested them as I could.

`font` support won't work, I think we need to use the following technique to register fonts: https://stackoverflow.com/a/40749435/299063

`nib`, `segue` and `storyboard` probably will work, but I didn't test it as I don't have a project using them near me now. If someone could test it, it would be nice.

`reuseIdentifier` - probably will work, not sure, needs testing.

`entitlements`, `info` — I guess we don't need these for bundles

`id` - not sure, needs testing.

_Note_: to test not enabled features, you need to enable them in `RswiftCore.swift:run()` (search for `supportedGenerators`)

_Note 2_: because bundle may fail to load at runtime, updated R.swift.Library is needed (where all Bundle references are changed to optional), here is corresponding PR: https://github.com/mac-cain13/R.swift.Library/pull/42
Other way could be force unwrap Bundle instance (in `R.bundle.<foo>.bundle` property), then no changes are needed in R.swift.Library. But I guess it is not right way to do as it could lead to crash if bundle is missing in runtime.

_Note 3_: I noticed that for color generation on watchOS an API without bundle support is used (`UIColor(named:)`), however I see that `UIColor(named:in:compatibleWith:)` is supported on watchOS 4.0+. I guess there are issues with it about which I am not aware. So I removed bundle color generation for watchOS for now.
