### PR TITLE
Generate resources of a Swift Package (without the need of Xcodeproj)

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,34 +1,95 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "Commander",
-        "repositoryURL": "https://github.com/kylef/Commander.git",
-        "state": {
-          "branch": null,
-          "revision": "4a1f2fb82fb6cef613c4a25d2e38f702e4d812c2",
-          "version": "0.9.2"
-        }
-      },
-      {
-        "package": "Spectre",
-        "repositoryURL": "https://github.com/kylef/Spectre.git",
-        "state": {
-          "branch": null,
-          "revision": "26cc5e9ae0947092c7139ef7ba612e34646086c7",
-          "version": "0.10.1"
-        }
-      },
-      {
-        "package": "XcodeEdit",
-        "repositoryURL": "https://github.com/tomlokhorst/XcodeEdit",
-        "state": {
-          "branch": null,
-          "revision": "99547c5af5850155b52c43b716ba1b094b02a3b2",
-          "version": "2.8.0"
-        }
+  "pins" : [
+    {
+      "identity" : "commander",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kylef/Commander.git",
+      "state" : {
+        "revision" : "4a1f2fb82fb6cef613c4a25d2e38f702e4d812c2",
+        "version" : "0.9.2"
       }
-    ]
-  },
-  "version": 1
+    },
+    {
+      "identity" : "spectre",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kylef/Spectre.git",
+      "state" : {
+        "revision" : "26cc5e9ae0947092c7139ef7ba612e34646086c7",
+        "version" : "0.10.1"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
+      "state" : {
+        "revision" : "e394bf350e38cb100b6bc4172834770ede1b7232",
+        "version" : "1.0.3"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "ddb07e896a2a8af79512543b1c7eb9797f8898a5",
+        "version" : "1.1.7"
+      }
+    },
+    {
+      "identity" : "swift-driver",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-driver.git",
+      "state" : {
+        "branch" : "release/5.6",
+        "revision" : "9982f32f96a2e0e597d1b4a0af4a7e997dc471be"
+      }
+    },
+    {
+      "identity" : "swift-llbuild",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-llbuild.git",
+      "state" : {
+        "branch" : "release/5.6",
+        "revision" : "acd686530e56122d916acd49a166beb9198e9b87"
+      }
+    },
+    {
+      "identity" : "swift-package-manager",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-package-manager",
+      "state" : {
+        "branch" : "release/5.6",
+        "revision" : "d53983abc7d1628a47ee26b24cbf35b06ac50f6e"
+      }
+    },
+    {
+      "identity" : "swift-tools-support-core",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-tools-support-core.git",
+      "state" : {
+        "branch" : "release/5.6",
+        "revision" : "107e570e3565920174d5a25bc3a0340b32d16042"
+      }
+    },
+    {
+      "identity" : "xcodeedit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tomlokhorst/XcodeEdit",
+      "state" : {
+        "revision" : "99547c5af5850155b52c43b716ba1b094b02a3b2",
+        "version" : "2.8.0"
+      }
+    },
+    {
+      "identity" : "yams",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jpsim/Yams.git",
+      "state" : {
+        "revision" : "9ff1cc9327586db4e0c8f46f064b6a82ec1566fa",
+        "version" : "4.0.6"
+      }
+    }
+  ],
+  "version" : 2
 }

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
     .target(name: "RswiftCore", dependencies: [
         .product(name: "Commander", package: "Commander"),
         .product(name: "XcodeEdit", package: "XcodeEdit"),
-        .product(name: "SwiftPM", package: "swift-package-manager")
+        .product(name: "SwiftPMDataModel-auto", package: "swift-package-manager")
     ]),
     .testTarget(name: "RswiftCoreTests", dependencies: ["RswiftCore"]),
   ]

--- a/Package.swift
+++ b/Package.swift
@@ -1,21 +1,26 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.6
 import PackageDescription
 
 let package = Package(
   name: "rswift",
   platforms: [
-    .macOS(.v10_11)
+    .macOS("10.15.4")
   ],
   products: [
     .executable(name: "rswift", targets: ["rswift"])
   ],
   dependencies: [
     .package(url: "https://github.com/kylef/Commander.git", from: "0.8.0"),
-    .package(url: "https://github.com/tomlokhorst/XcodeEdit", from: "2.8.0")
+    .package(url: "https://github.com/tomlokhorst/XcodeEdit", from: "2.8.0"),
+    .package(url: "https://github.com/apple/swift-package-manager", branch: "release/5.6")
   ],
   targets: [
-    .target(name: "rswift", dependencies: ["RswiftCore"]),
-    .target(name: "RswiftCore", dependencies: ["Commander", "XcodeEdit"]),
+    .executableTarget(name: "rswift", dependencies: ["RswiftCore"]),
+    .target(name: "RswiftCore", dependencies: [
+        .product(name: "Commander", package: "Commander"),
+        .product(name: "XcodeEdit", package: "XcodeEdit"),
+        .product(name: "SwiftPM", package: "swift-package-manager")
+    ]),
     .testTarget(name: "RswiftCoreTests", dependencies: ["RswiftCore"]),
   ]
 )

--- a/Sources/RswiftCore/CallInformation.swift
+++ b/Sources/RswiftCore/CallInformation.swift
@@ -10,6 +10,11 @@
 import Foundation
 import XcodeEdit
 
+public enum ResourcesOrigin {
+    case swiftPackage(URL)
+    case xcodeproj(URL)
+}
+
 public struct CallInformation {
   let outputURL: URL
   let uiTestOutputURL: URL?
@@ -19,7 +24,7 @@ public struct CallInformation {
   let accessLevel: AccessLevel
   let imports: [Module]
 
-  let xcodeprojURL: URL
+  let resourcesOrigin: ResourcesOrigin
   let targetName: String
   let bundleIdentifier: String
   let productModuleName: String
@@ -41,7 +46,7 @@ public struct CallInformation {
     accessLevel: AccessLevel,
     imports: [Module],
 
-    xcodeprojURL: URL,
+    resourcesOrigin: ResourcesOrigin,
     targetName: String,
     bundleIdentifier: String,
     productModuleName: String,
@@ -62,7 +67,8 @@ public struct CallInformation {
     self.imports = imports
     self.generators = generators
 
-    self.xcodeprojURL = xcodeprojURL
+//    self.xcodeprojURL = xcodeprojURL
+    self.resourcesOrigin = resourcesOrigin
     self.targetName = targetName
     self.bundleIdentifier = bundleIdentifier
     self.productModuleName = productModuleName

--- a/Sources/RswiftCore/CallInformation.swift
+++ b/Sources/RswiftCore/CallInformation.swift
@@ -82,7 +82,6 @@ public struct CallInformation {
     self.platformURL = platformURL
   }
 
-
   func urlForSourceTreeFolder(_ sourceTreeFolder: SourceTreeFolder) -> URL {
     switch sourceTreeFolder {
     case .buildProductsDir:
@@ -96,5 +95,10 @@ public struct CallInformation {
     case .platformDir:
       return platformURL
     }
+  }
+
+  var isSwiftPackage: Bool {
+    guard case .swiftPackage = resourcesOrigin else { return false }
+    return true
   }
 }

--- a/Sources/RswiftCore/RswiftCore.swift
+++ b/Sources/RswiftCore/RswiftCore.swift
@@ -53,14 +53,13 @@ public struct RswiftCore {
 
   private func findResources(for target: PackageModel.Target, ignoreFile: IgnoreFile?) throws -> Resources {
     let ignoreFile = ignoreFile ?? IgnoreFile()
-    let resourceURLs = target.resources.compactMap { resource -> URL? in
-      if resource.rule == .process, let ext = resource.path.extension {
-        // ExcludeProcessExtension(rawValue: ext) != nil {
-        // Skip processed resource named '\(resource.path.basename)'
-        return nil
-      }
+    var resourceURLs = target.resources.compactMap { resource -> URL? in
       return resource.path.asURL
     }.filter { !ignoreFile.matches(url: $0) }
+
+    resourceURLs.append(contentsOf: target.others.compactMap { other -> URL? in
+        return other.asURL
+    }.filter { !ignoreFile.matches(url: $0) })
 
     return Resources(resourceURLs: resourceURLs, fileManager: FileManager.default)
   }

--- a/Sources/RswiftCore/RswiftCore.swift
+++ b/Sources/RswiftCore/RswiftCore.swift
@@ -206,7 +206,8 @@ public struct RswiftCore {
     let (externalStructWithoutProperties, internalStruct) = ValidatedStructGenerator(validationSubject: aggregatedResult)
       .generatedStructs(at: callInformation.accessLevel, prefix: "")
 
-    let externalStruct = externalStructWithoutProperties.addingInternalProperties(forBundleIdentifier: callInformation.bundleIdentifier)
+    let externalStruct = externalStructWithoutProperties.addingInternalProperties(
+      forBundleIdentifier: callInformation.bundleIdentifier, isSwiftPackage: callInformation.isSwiftPackage)
 
     let codeConvertibles: [SwiftCodeConverible?] = [
       HeaderPrinter(),

--- a/Sources/RswiftCore/RswiftCore.swift
+++ b/Sources/RswiftCore/RswiftCore.swift
@@ -265,15 +265,6 @@ private func writeIfChanged(contents: String, toURL outputURL: URL) {
 
 // MARK: - Swift Package Graph
 
-private func resolveSwiftCompilerPath() throws -> AbsolutePath {
-  let path: String
-  #if os(macOS)
-  path = try Process.checkNonZeroExit(args: "xcrun", "--sdk", "macosx", "-f", "swiftc").spm_chomp()
-  #else
-  path = try! Process.checkNonZeroExit(args: "which", "swiftc").spm_chomp()
-  #endif
-  return AbsolutePath(path)
-}
 
 func loadSwiftPackageGraph(packageURL: URL) throws -> PackageGraph {
   let observability = ObservabilitySystem { scope, diagnotic in

--- a/Sources/RswiftCore/Util/Struct+InternalProperties.swift
+++ b/Sources/RswiftCore/Util/Struct+InternalProperties.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 extension Struct {
-  func addingInternalProperties(forBundleIdentifier bundleIdentifier: String) -> Struct {
+  func addingInternalProperties(forBundleIdentifier bundleIdentifier: String, isSwiftPackage: Bool) -> Struct {
 
     let internalProperties = [
       Let(
@@ -18,7 +18,7 @@ extension Struct {
         isStatic: true,
         name: "hostingBundle",
         typeDefinition: .inferred(Type._Bundle),
-        value: "Bundle(for: R.Class.self)"),
+        value: isSwiftPackage ? "Bundle.module" : "Bundle(for: R.Class.self)"),
       Let(
         comments: [],
         accessModifier: .filePrivate,

--- a/Sources/rswift/main.swift
+++ b/Sources/rswift/main.swift
@@ -239,8 +239,14 @@ let generate = command(
     warn("For updating to R.swift 6.0, read our migration guide: https://github.com/mac-cain13/R.swift/blob/master/Documentation/Migration.md")
   }
 
-  let xcodeproj = try? processInfo.environmentVariable(name: EnvironmentKeys.xcodeproj)
-  let swiftPackage = try? processInfo.environmentVariable(name: EnvironmentKeys.swiftPackage)
+
+  var swiftPackage = try? processInfo.environmentVariable(name: EnvironmentKeys.swiftPackage)
+  var xcodeproj = try? processInfo.environmentVariable(name: EnvironmentKeys.xcodeproj)
+
+  if (xcodeproj as? NSString)?.lastPathComponent == "Package.swift" {
+    swiftPackage = xcodeproj
+    xcodeproj = nil
+  }
 
   let resourcesOrigin: ResourcesOrigin
 


### PR DESCRIPTION
Dear community,

Being able to generate / use R.swift inside a Swift Package is a necessary need with the growing amount of swift packages, and also to allow developers to use R.swift in their own internal dependencies that would be architectures as swift packages.

This pull request is functional in the sense that it is able to generate the R.generated.swift for a given target of a swift package, here is how :
- requires only environment variables **SWIFT_PACKAGE** and **TARGET_NAME**
- use `rswift generate "${SWIFT_PACKAGE}/Sources/${TARGET_NAME}/R.generated.swift"`

It is unperfect since it only relies on the latest swift tools, and that it doesn't take advantage of the `plugin` API that was introduced with swift 5.6

I believe this is a first step and would love contributions of active members to make it real.

Thanks.
