### PR TITLE
R.generated file do not need to import both Foundation and UIKit

### DIFF
--- a/Sources/RswiftCore/SwiftTypes/CodeGenerators/ImportPrinter.swift
+++ b/Sources/RswiftCore/SwiftTypes/CodeGenerators/ImportPrinter.swift
@@ -31,6 +31,7 @@ struct ImportPrinter: SwiftCodeConverible {
     modulesToImport.append(contentsOf: extractedModulesArray)
 
     swiftCode = modulesToImport
+      .filter { !($0 == "Foundation" && modulesToImport.contains("UIKit")) }
       .map { "import \($0)" }
       .joined(separator: "\n")
   }


### PR DESCRIPTION
- If **R.generated** file needs Foundation types, import Foundation.
- If **R.generated** file needs UIKit types (they all start with `UI`), import UIKit.

UIKit itself imports Foundation

Therefore if a file imports UIKit, it does not need to import Foundation explicitly
<img width="366" alt="uikit" src="https://user-images.githubusercontent.com/55218398/201647562-b261d71d-f6bb-48b1-99b2-2afc96fba974.png">
