### PR TITLE
Add function to get `Data` from `DataResource` directly

### DIFF
--- a/Sources/RswiftResources/Integrations/DataResource+Integrations.swift
+++ b/Sources/RswiftResources/Integrations/DataResource+Integrations.swift
@@ -25,3 +25,9 @@ extension NSDataAsset {
     }
 
 }
+
+extension DataResource {
+    public func callAsFunction() -> Data? {
+        NSDataAsset(resource: self)?.data
+    }
+}


### PR DESCRIPTION
Addresses #454 

There is only a simple initializer of `NSDataAsset` currently.

```swift
if let asset = NSDataAsset(resource: R.data.animation) {
    let data = asset.data
}
```

This PR makes it possible to call like `let data = R.data.animation()`