### PR TITLE
Compare URLs with resolved symlinks

### DIFF
--- a/Sources/RswiftParsers/Resources/AssetCatalog+Parser.swift
+++ b/Sources/RswiftParsers/Resources/AssetCatalog+Parser.swift
@@ -53,7 +53,7 @@ extension AssetCatalog: SupportedExtensions {
         var namespaces: [URL: NamespaceDirectory] = [URL(fileURLWithPath: ".", relativeTo: catalogURL): root]
 
         for case let fileURL as URL in directoryEnumerator {
-            guard fileURL.baseURL == catalogURL else {
+            guard fileURL.baseURL?.resolvingSymlinksInPath() == catalogURL.resolvingSymlinksInPath() else {
                 throw ResourceParsingError("File \(fileURL) is not in AssetCatalog \(catalogURL)")
             }
 


### PR DESCRIPTION
This fixes a base path mismatch when assets URLs are located in `/private/tmp`.
See https://stackoverflow.com/questions/43031045/for-what-paths-is-resolvingsymlinksinpath-wrong