### PR TITLE
Fix sourceRootURL

### DIFF
--- a/Sources/rswift/App.swift
+++ b/Sources/rswift/App.swift
@@ -88,7 +88,7 @@ extension App {
             let sourceTreeURLs = SourceTreeURLs(
                 builtProductsDirURL: URL(fileURLWithPath: processInfo.environment[EnvironmentKeys.builtProductsDir] ?? EnvironmentKeys.builtProductsDir),
                 developerDirURL: URL(fileURLWithPath: processInfo.environment[EnvironmentKeys.developerDir] ?? EnvironmentKeys.developerDir),
-                sourceRootURL: URL(fileURLWithPath: processInfo.environment[EnvironmentKeys.sourceRoot] ?? EnvironmentKeys.sourceRoot),
+                sourceRootURL: URL(fileURLWithPath: processInfo.environment[EnvironmentKeys.sourceRoot] ?? ""),
                 sdkRootURL: URL(fileURLWithPath: processInfo.environment[EnvironmentKeys.sdkRoot] ?? EnvironmentKeys.sdkRoot),
                 platformURL: URL(fileURLWithPath: processInfo.environment[EnvironmentKeys.platformDir] ?? EnvironmentKeys.platformDir)
             )


### PR DESCRIPTION
R.swift cannot find .rswiftignore for a project that isn't made by xcodeproj but Package.swift.

It is because that `SOURCE_ROOT` environment variable doesn't exist when a project is build with Package.swift and currently the source code references `./SOURCE_ROOT` literally.

issue: #819 