### PR TITLE
Use current locale when overrideLocale is missing

### DIFF
--- a/Sources/RswiftResources/Integrations/StringResource+Integrations.swift
+++ b/Sources/RswiftResources/Integrations/StringResource+Integrations.swift
@@ -14,7 +14,7 @@ extension String {
         case let .hosting(bundle):
             // With fallback to developmentValue
             let format = NSLocalizedString(key.description, tableName: tableName, bundle: bundle, value: developmentValue ?? "", comment: "")
-            self = String(format: format, locale: overrideLocale, arguments: arguments)
+            self = String(format: format, locale: overrideLocale ?? Locale.current, arguments: arguments)
 
         case let .selected(bundle, locale):
             // Don't use developmentValue with selected bundle/locale


### PR DESCRIPTION
As described in issue #812, when localizing strings containing arguments like "My number: %d", Rswift does not use the locale of the current environment when the locale argument is missing (which is the default behavior). So the string cannot be formatted correctly.

For example, in `Localizable.strings` in Japanese, when using %d, a comma should be inserted every three digits:
```
"My number: %d" = "数値：%d";
```

Current Rswift gives us this:
```swift
R.string.localizable.myNumberD(1234567890)
// 数値：1234567890

R.string(locale: Locale(identifier: "ja")).localizable.myNumberD(1234567890)
// 数値：1,234,567,890
```

After PR:
```swift
R.string.localizable.myNumberD(1234567890)
// 数値：1,234,567,890

R.string(locale: Locale(identifier: "ja")).localizable.myNumberD(1234567890)
// 数値：1,234,567,890
```

As comparison, iOS's behaviour is
```swift
let num = 1234567890

Text("Text: \(num)")
// Text: 1,234,567,890

Text(String(format: "String format: %d", num))
// String format: 1234567890

Text(String.localizedStringWithFormat("localizedStringWithFormat: %d", num))
// localizedStringWithFormat: 1,234,567,890
```