### PR TITLE
Conflict with SwiftUI: Renaming Classes to RImageRessource and RColorRessource

### DIFF
--- a/Sources/RswiftGenerators/AssetCatalog+Generator.swift
+++ b/Sources/RswiftGenerators/AssetCatalog+Generator.swift
@@ -13,7 +13,7 @@ public protocol AssetCatalogContent {
     func generateVarGetter() -> VarGetter
 }
 
-extension ColorResource {
+extension RColorResource {
     public static func generateStruct(catalogs: [AssetCatalog], prefix: SwiftIdentifier) -> Struct {
         let merged: AssetCatalog.Namespace = catalogs.map(\.root).reduce(.init(), { $0.merging($1) })
 
@@ -29,8 +29,8 @@ extension DataResource {
     }
 }
 
-extension ImageResource {
-    public static func generateStruct(catalogs: [AssetCatalog], toplevel resources: [ImageResource], prefix: SwiftIdentifier) -> Struct {
+extension RImageResource {
+    public static func generateStruct(catalogs: [AssetCatalog], toplevel resources: [RImageResource], prefix: SwiftIdentifier) -> Struct {
         // Multiple resources can share same name,
         // for example: Colors.jpg and Colors@2x.jpg are both named "Colors.jpg"
         // Deduplicate these
@@ -97,14 +97,14 @@ extension AssetCatalog.Namespace {
     }
 }
 
-extension ColorResource: AssetCatalogContent {
+extension RColorResource: AssetCatalogContent {
     public func generateVarGetter() -> VarGetter {
         let fullname = (path + [name]).joined(separator: "/")
         let code = ".init(name: \"\(fullname.escapedStringLiteral)\", path: \(path), bundle: bundle)"
         return VarGetter(
             comments: ["Color `\(fullname)`."],
             name: SwiftIdentifier(name: name),
-            typeReference: TypeReference(module: .rswiftResources, rawName: "ColorResource"),
+            typeReference: TypeReference(module: .rswiftResources, rawName: "RColorResource"),
             valueCodeString: code
         )
     }
@@ -124,7 +124,7 @@ extension DataResource: AssetCatalogContent {
     }
 }
 
-extension ImageResource: AssetCatalogContent {
+extension RImageResource: AssetCatalogContent {
     public func generateVarGetter() -> VarGetter {
         let locs = locale.map { $0.codeString() } ?? "nil"
         let odrt = onDemandResourceTags?.debugDescription ?? "nil"
@@ -133,7 +133,7 @@ extension ImageResource: AssetCatalogContent {
         return VarGetter(
             comments: ["Image `\(fullname)`."],
             name: SwiftIdentifier(name: name),
-            typeReference: TypeReference(module: .rswiftResources, rawName: "ImageResource"),
+            typeReference: TypeReference(module: .rswiftResources, rawName: "RImageResource"),
             valueCodeString: code
         )
     }

--- a/Sources/RswiftGenerators/FontResource+Generator.swift
+++ b/Sources/RswiftGenerators/FontResource+Generator.swift
@@ -1,5 +1,5 @@
 //
-//  FontResource+Generator.swift
+// RFontResource+Generator.swift
 //  rswift
 //
 //  Created by Tom Lokhorst on 2021-04-18.
@@ -8,8 +8,8 @@
 import Foundation
 import RswiftResources
 
-extension FontResource {
-    public static func generateStruct(resources: [FontResource], prefix: SwiftIdentifier) -> Struct {
+extension RFontResource {
+    public static func generateStruct(resources: [RFontResource], prefix: SwiftIdentifier) -> Struct {
         let structName = SwiftIdentifier(name: "font")
         let qualifiedName = prefix + structName
         let warning: (String) -> Void = { print("warning: [R.swift]", $0) }
@@ -36,7 +36,7 @@ extension FontResource {
             comments: [],
             name: .init(name: "makeIterator"),
             params: [],
-            returnType: .indexingIterator(.fontResource),
+            returnType: .indexingIterator(.RFontResource),
             valueCodeString: "[\(names.map(\.value).joined(separator: ", "))].makeIterator()"
         )
     }
@@ -57,12 +57,12 @@ extension FontResource {
     }
 }
 
-extension FontResource {
+extension RFontResource {
     func generateVarGetter() -> VarGetter {
         VarGetter(
             comments: ["Font `\(name)`."],
             name: SwiftIdentifier(name: name),
-            typeReference: TypeReference(module: .rswiftResources, rawName: "FontResource"),
+            typeReference: TypeReference(module: .rswiftResources, rawName: "RFontResource"),
             valueCodeString: ".init(name: \"\(name)\", bundle: bundle, filename: \"\(filename)\")"
         )
     }

--- a/Sources/RswiftGenerators/Shared/TypeReference+Generator.swift
+++ b/Sources/RswiftGenerators/Shared/TypeReference+Generator.swift
@@ -44,5 +44,5 @@ extension TypeReference {
     static var nsViewController: TypeReference = .init(module: .appKit, rawName: "NSViewController")
 
 
-    static var fontResource: TypeReference = .init(module: .rswiftResources, rawName: "FontResource")
+    static var RFontResource: TypeReference = .init(module: .rswiftResources, rawName: "RFontResource")
 }

--- a/Sources/RswiftParsers/ProjectResources.swift
+++ b/Sources/RswiftParsers/ProjectResources.swift
@@ -29,8 +29,8 @@ public enum ResourceType: String, CaseIterable {
 public struct ProjectResources {
     public let assetCatalogs: [AssetCatalog]
     public let files: [FileResource]
-    public let fonts: [FontResource]
-    public let images: [ImageResource]
+    public let fonts: [RFontResource]
+    public let images: [RImageResource]
     public let strings: [StringsTable]
     public let nibs: [NibResource]
     public let storyboards: [StoryboardResource]
@@ -104,8 +104,8 @@ public struct ProjectResources {
 
         let assetCatalogs: [AssetCatalog]
         let files: [FileResource]
-        let fonts: [FontResource]
-        let images: [ImageResource]
+        let fonts: [RFontResource]
+        let images: [RImageResource]
         let strings: [StringsTable]
         let nibs: [NibResource]
         let storyboards: [StoryboardResource]
@@ -123,8 +123,8 @@ public struct ProjectResources {
             let dontParseFileForImages = !parseImagesAsFiles
             files = try urls
                 .filter { !FileResource.unsupportedExtensions.contains($0.pathExtension) }
-                .filter { !(dontParseFileForFonts && FontResource.supportedExtensions.contains($0.pathExtension)) }
-                .filter { !(dontParseFileForImages && ImageResource.supportedExtensions.contains($0.pathExtension)) }
+                .filter { !(dontParseFileForFonts && RFontResource.supportedExtensions.contains($0.pathExtension)) }
+                .filter { !(dontParseFileForImages && RImageResource.supportedExtensions.contains($0.pathExtension)) }
                 .compactMap { url in try parse(with: warning) { try FileResource.parse(url: url) } }
         } else {
             files = []
@@ -132,16 +132,16 @@ public struct ProjectResources {
 
         if resourceTypes.contains(.font) {
             fonts = try urls
-                .filter { FontResource.supportedExtensions.contains($0.pathExtension) }
-                .compactMap { url in try parse(with: warning) { try FontResource.parse(url: url) } }
+                .filter { RFontResource.supportedExtensions.contains($0.pathExtension) }
+                .compactMap { url in try parse(with: warning) { try RFontResource.parse(url: url) } }
         } else {
             fonts = []
         }
 
         if resourceTypes.contains(.image) {
             images = try urls
-                .filter { ImageResource.supportedExtensions.contains($0.pathExtension) }
-                .compactMap { url in try parse(with: warning) { try ImageResource.parse(url: url, assetTags: nil) } }
+                .filter { RImageResource.supportedExtensions.contains($0.pathExtension) }
+                .compactMap { url in try parse(with: warning) { try RImageResource.parse(url: url, assetTags: nil) } }
         } else {
             images = []
         }

--- a/Sources/RswiftParsers/Resources/AssetCatalog+Parser.swift
+++ b/Sources/RswiftParsers/Resources/AssetCatalog+Parser.swift
@@ -109,13 +109,13 @@ extension AssetCatalog: SupportedExtensions {
             subnamespaces[name] = namespace
         }
 
-        var colors: [ColorResource] = []
+        var colors: [RColorResource] = []
         for fileURL in directory.colors {
             let name = fileURL.filenameWithoutExtension!
             colors.append(.init(name: name, path: path, bundle: .temp))
         }
 
-        var images: [ImageResource] = []
+        var images: [RImageResource] = []
         for fileURL in directory.images {
             let name = fileURL.filenameWithoutExtension!
             let tags = parseOnDemandResourceTags(directory: fileURL)

--- a/Sources/RswiftParsers/Resources/FontResource+Parser.swift
+++ b/Sources/RswiftParsers/Resources/FontResource+Parser.swift
@@ -1,5 +1,5 @@
 //
-//  FontResource.swift
+// RFontResource.swift
 //  R.swift
 //
 //  Created by Mathijs Kadijk on 09-12-15.
@@ -9,10 +9,10 @@ import Foundation
 import RswiftResources
 import CoreGraphics
 
-extension FontResource: SupportedExtensions {
+extension RFontResource: SupportedExtensions {
     static public let supportedExtensions: Set<String> = ["otf", "ttf"]
 
-    static public func parse(url: URL) throws -> FontResource {
+    static public func parse(url: URL) throws -> RFontResource {
         guard let dataProvider = CGDataProvider(url: url as CFURL) else {
             throw ResourceParsingError("Unable to create data provider for font at \(url)")
         }
@@ -22,7 +22,7 @@ extension FontResource: SupportedExtensions {
             throw ResourceParsingError("No postscriptName associated to font at \(url)")
         }
 
-        return FontResource(
+        return RFontResource(
             name: postScriptName as String,
             bundle: .temp,
             filename: url.lastPathComponent

--- a/Sources/RswiftParsers/Resources/ImageResource+Parser.swift
+++ b/Sources/RswiftParsers/Resources/ImageResource+Parser.swift
@@ -1,5 +1,5 @@
 //
-//  ImageResource.swift
+//  RImageResource.swift
 //  R.swift
 //
 //  Created by Mathijs Kadijk on 09-12-15.
@@ -10,11 +10,11 @@ import RswiftResources
 import CoreGraphics
 
 
-extension ImageResource: SupportedExtensions {
+extension RImageResource: SupportedExtensions {
     // See "Supported Image Formats" on https://developer.apple.com/library/ios/documentation/UIKit/Reference/UIImage_Class/
     static public let supportedExtensions: Set<String> = ["tiff", "tif", "jpg", "jpeg", "gif", "png", "bmp", "bmpf", "ico", "cur", "xbm"]
 
-    static public func parse(url: URL, assetTags: [String]?) throws -> ImageResource {
+    static public func parse(url: URL, assetTags: [String]?) throws -> RImageResource {
         let filename = url.lastPathComponent
         let pathExtension = url.pathExtension
         guard filename.count > 0 && pathExtension.count > 0 else {
@@ -23,12 +23,12 @@ extension ImageResource: SupportedExtensions {
 
         let locale = LocaleReference(url: url)
 
-        let extensions = ImageResource.supportedExtensions.joined(separator: "|")
+        let extensions = RImageResource.supportedExtensions.joined(separator: "|")
         let regex = try! NSRegularExpression(pattern: "(~(ipad|iphone))?(@[2,3]x)?\\.(\(extensions))$", options: .caseInsensitive)
         let fullFileNameRange = NSRange(location: 0, length: filename.count)
         let pathExtensionToUse = (pathExtension == "png") ? "" : ".\(pathExtension)"
         let name = regex.stringByReplacingMatches(in: filename, options: NSRegularExpression.MatchingOptions(rawValue: 0), range: fullFileNameRange, withTemplate: pathExtensionToUse)
 
-        return ImageResource(name: name, path: [], bundle: .temp, locale: locale, onDemandResourceTags: assetTags)
+        return RImageResource(name: name, path: [], bundle: .temp, locale: locale, onDemandResourceTags: assetTags)
     }
 }

--- a/Sources/RswiftResources/AssetCatalog.swift
+++ b/Sources/RswiftResources/AssetCatalog.swift
@@ -20,8 +20,8 @@ public struct AssetCatalog {
 extension AssetCatalog {
     public struct Namespace {
         public var subnamespaces: [String: Namespace] = [:]
-        public var colors: [ColorResource] = []
-        public var images: [ImageResource] = []
+        public var colors: [RColorResource] = []
+        public var images: [RImageResource] = []
         public var dataAssets: [DataResource] = []
 
         public init() {
@@ -29,8 +29,8 @@ extension AssetCatalog {
 
         public init(
             subnamespaces: [String: Namespace],
-            colors: [ColorResource],
-            images: [ImageResource],
+            colors: [RColorResource],
+            images: [RImageResource],
             dataAssets: [DataResource]
         ) {
             self.subnamespaces = subnamespaces

--- a/Sources/RswiftResources/Integrations/ColorResource+Integrations.swift
+++ b/Sources/RswiftResources/Integrations/ColorResource+Integrations.swift
@@ -16,7 +16,7 @@ extension Color {
 
      - parameter resource: The resource you want the color of (`R.color.*`)
      */
-    public init(_ resource: ColorResource) {
+    public init(_ resource: RColorResource) {
         self.init(resource.name, bundle: resource.bundle)
     }
 }
@@ -25,7 +25,7 @@ extension Color {
 #if os(iOS) || os(tvOS) || os(visionOS)
 import UIKit
 
-extension ColorResource {
+extension RColorResource {
 
     /**
      Returns the color from this resource (`R.color.*`) that is compatible with the trait collection.
@@ -51,7 +51,7 @@ extension UIColor {
 
      - returns: A color that exactly or best matches the desired traits with the given resource (`R.color.*`), or nil if no suitable color was found.
      */
-    public convenience init?(resource: ColorResource, compatibleWith traitCollection: UITraitCollection? = nil) {
+    public convenience init?(resource: RColorResource, compatibleWith traitCollection: UITraitCollection? = nil) {
         self.init(named: resource.name, in: resource.bundle, compatibleWith: traitCollection)
     }
 

--- a/Sources/RswiftResources/Integrations/FontResource+Integrations.swift
+++ b/Sources/RswiftResources/Integrations/FontResource+Integrations.swift
@@ -15,7 +15,7 @@ extension Font {
     /**
      Create a custom font from this resource (`R.font.*`) and and size that scales with the body text style.
      */
-    public static func custom(_ resource: FontResource, size: CGFloat) -> Font {
+    public static func custom(_ resource: RFontResource, size: CGFloat) -> Font {
         .custom(resource.name, size: size)
     }
 
@@ -23,7 +23,7 @@ extension Font {
      Create a custom font from this resource (`R.font.*`) and a fixed size that does not scale with Dynamic Type.
      */
     @available(macOS 11, iOS 14, tvOS 14, watchOS 7, visionOS 1, *)
-    public static func custom(_ resource: FontResource, fixedSize: CGFloat) -> Font {
+    public static func custom(_ resource: RFontResource, fixedSize: CGFloat) -> Font {
         .custom(resource.name, fixedSize: fixedSize)
     }
 
@@ -31,7 +31,7 @@ extension Font {
      Create a custom font from this resource (`R.font.*`) and and size that is relative to the given `textStyle`.
      */
     @available(macOS 11, iOS 14, tvOS 14, watchOS 7, visionOS 1, *)
-    public static func custom(_ resource: FontResource, size: CGFloat, relativeTo textStyle: Font.TextStyle) -> Font {
+    public static func custom(_ resource: RFontResource, size: CGFloat, relativeTo textStyle: Font.TextStyle) -> Font {
         .custom(resource.name, size: size, relativeTo: textStyle)
     }
 }
@@ -39,7 +39,7 @@ extension Font {
 #if canImport(UIKit)
 import UIKit
 
-extension FontResource {
+extension RFontResource {
 
     /**
      Returns the font from this resource (`R.font.*`) at the specified zie.
@@ -64,7 +64,7 @@ public extension UIFont {
 
      - returns: A font object of the specified font resource and size.
      */
-    convenience init?(resource: FontResource, size: CGFloat) {
+    convenience init?(resource: RFontResource, size: CGFloat) {
         self.init(name: resource.name, size: size)
     }
 }
@@ -74,7 +74,7 @@ public extension UIFont {
 #if canImport(UIKit)
 import UIKit
 
-extension FontResource {
+extension RFontResource {
     /**
      Returns true if the font can be loaded.
      Custom fonts may not be loaded if not properly configured in Info.plist
@@ -86,7 +86,7 @@ extension FontResource {
 #elseif canImport(AppKit)
 import AppKit
 
-extension FontResource {
+extension RFontResource {
     /**
      Returns true if the font can be loaded.
      Custom fonts may not be loaded if not properly configured in Info.plist

--- a/Sources/RswiftResources/Integrations/ImageResource+Integrations.swift
+++ b/Sources/RswiftResources/Integrations/ImageResource+Integrations.swift
@@ -17,7 +17,7 @@ extension Image {
 
      - parameter resource: The resource you want the image of (`R.image.*`)
      */
-    public init(_ resource: ImageResource) {
+    public init(_ resource: RImageResource) {
         self.init(resource.name, bundle: resource.bundle)
     }
 
@@ -28,7 +28,7 @@ extension Image {
      - parameter resource: The resource you want the image of (`R.image.*`)
      - parameter label: The label associated with the image, for accessibility
      */
-    public init(_ resource: ImageResource, label: Text) {
+    public init(_ resource: RImageResource, label: Text) {
         self.init(resource.name, bundle: resource.bundle, label: label)
     }
 
@@ -38,7 +38,7 @@ extension Image {
 
      - parameter resource: The resource you want the image of (`R.image.*`)
      */
-    public init(decorative resource: ImageResource) {
+    public init(decorative resource: RImageResource) {
         self.init(decorative: resource.name, bundle: resource.bundle)
     }
 }
@@ -55,7 +55,7 @@ extension Image {
      - parameter resource: The resource you want the image of (`R.image.*`)
      - parameter variableValue: Optional value between 1 and 0
      */
-    public init(_ resource: ImageResource, variableValue: Double?) {
+    public init(_ resource: RImageResource, variableValue: Double?) {
         self.init(resource.name, variableValue: variableValue, bundle: resource.bundle)
     }
 
@@ -67,7 +67,7 @@ extension Image {
      - parameter variableValue: Optional value between 1 and 0
      - parameter label: The label associated with the image, for accessibility
      */
-    public init(_ resource: ImageResource, variableValue: Double?, label: Text) {
+    public init(_ resource: RImageResource, variableValue: Double?, label: Text) {
         self.init(resource.name, variableValue: variableValue, bundle: resource.bundle, label: label)
     }
 
@@ -78,7 +78,7 @@ extension Image {
      - parameter resource: The resource you want the image of (`R.image.*`)
      - parameter variableValue: Optional value between 1 and 0
      */
-    public init(decorative resource: ImageResource, variableValue: Double?) {
+    public init(decorative resource: RImageResource, variableValue: Double?) {
         self.init(decorative: resource.name, variableValue: variableValue, bundle: resource.bundle)
     }
 }
@@ -88,7 +88,7 @@ extension Image {
 #if os(iOS) || os(tvOS) || os(visionOS)
 import UIKit
 
-extension ImageResource {
+extension RImageResource {
 
     /**
      Returns the image from this resource (`R.image.*`) that is compatible with the trait collection.
@@ -114,7 +114,7 @@ extension UIImage {
 
      - returns: An image that exactly or best matches the desired traits with the given resource (`R.image.*`), or nil if no suitable image was found.
      */
-    public convenience init?(resource: ImageResource, compatibleWith traitCollection: UITraitCollection? = nil) {
+    public convenience init?(resource:RImageResource, compatibleWith traitCollection: UITraitCollection? = nil) {
         self.init(named: resource.name, in: resource.bundle, compatibleWith: traitCollection)
     }
 
@@ -127,7 +127,7 @@ extension UIImage {
      - returns: An image that exactly or best matches the configuration of the given resource (`R.image.*`), or nil if no suitable image was found.
      */
     @available(iOS 13, tvOS 13, visionOS 1, *)
-    public convenience init?(resource: ImageResource, with configuration: UIImage.Configuration?) {
+    public convenience init?(resource:RImageResource, with configuration: UIImage.Configuration?) {
         self.init(named: resource.name, in: resource.bundle, with: configuration)
     }
 }
@@ -148,7 +148,7 @@ extension UIImage {
      - returns: An image that exactly or best matches the configuration of the given resource (`R.image.*`), or nil if no suitable image was found.
      */
     @available(iOS 16, tvOS 16, visionOS 1, *)
-    public convenience init?(resource: ImageResource, variableValue: Double, with configuration: UIImage.Configuration? = nil) {
+    public convenience init?(resource:RImageResource, variableValue: Double, with configuration: UIImage.Configuration? = nil) {
         self.init(named: resource.name, in: resource.bundle, variableValue: variableValue, configuration: configuration)
     }
 }

--- a/Sources/RswiftResources/RColorResource.swift
+++ b/Sources/RswiftResources/RColorResource.swift
@@ -1,5 +1,5 @@
 //
-//  ColorResource.swift
+//  RColorResource.swift
 //  
 //
 //  Created by Tom Lokhorst on 2022-07-23.
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct ColorResource {
+public struct RColorResource {
     public let name: String
     public let path: [String]
     public let bundle: Bundle

--- a/Sources/RswiftResources/RFontResource.swift
+++ b/Sources/RswiftResources/RFontResource.swift
@@ -1,5 +1,5 @@
 //
-//  FontResource.swift
+// RFontResource.swift
 //  R.swift
 //
 //  Created by Mathijs Kadijk on 09-12-15.
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct FontResource {
+public struct RFontResource {
     public let name: String
     public let bundle: Bundle
     public let filename: String

--- a/Sources/RswiftResources/RImageResource.swift
+++ b/Sources/RswiftResources/RImageResource.swift
@@ -1,5 +1,5 @@
 //
-//  ImageResource.swift
+// RImageResource.swift
 //  R.swift
 //
 //  Created by Mathijs Kadijk on 09-12-15.
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct ImageResource {
+public struct RImageResource {
     public let name: String
     public let path: [String]
     public let bundle: Bundle

--- a/Sources/rswift/RswiftCore.swift
+++ b/Sources/rswift/RswiftCore.swift
@@ -114,12 +114,12 @@ public struct RswiftCore {
             prefix: qualifiedName
         )
 
-        let imageStruct = ImageResource.generateStruct(
+        let imageStruct = RImageResource.generateStruct(
             catalogs: resources.assetCatalogs,
             toplevel: resources.images,
             prefix: qualifiedName
         )
-        let colorStruct = ColorResource.generateStruct(
+        let colorStruct = RColorResource.generateStruct(
             catalogs: resources.assetCatalogs,
             prefix: qualifiedName
         )
@@ -139,7 +139,7 @@ public struct RswiftCore {
             prefix: qualifiedName
         )
 
-        let fontStruct = FontResource.generateStruct(
+        let fontStruct = RFontResource.generateStruct(
             resources: resources.fonts,
             prefix: qualifiedName
         )


### PR DESCRIPTION
### Problem:

Apple has introduced two new classes, **ImageResource** and **ColorResource**, in SwiftUI. These classes have the same names as our existing classes, **ImageRessource** and **ColorRessource**, which has led to a naming conflict.

### Solution:
To avoid this conflict and ensure the smooth functioning of our package, I have renamed our classes as follows:

- _ImageRessource_ is now **RImageRessource**
- _ColorRessource_ is now **RColorRessource**

### Why This Change is Necessary:
By renaming our classes, we prevent any ambiguity when developers use our package alongside SwiftUI. This change aligns with best practices to avoid naming conflicts and ensures that our package remains compatible with the latest iOS SDK.

### Links to Apple Documentation:

[Apple's ImageResource Documentation](https://developer.apple.com/documentation/developertoolssupport/imageresource)
[Apple's ColorResource Documentation](https://developer.apple.com/documentation/developertoolssupport/colorresource)

### Impact:
This change may require updates in the codebase where our package is used. Developers will need to update references to the old class names (_ImageRessource_ and _ColorRessource_) to the new names (**RImageRessource** and RColorRessource) to ensure compatibility.