### PR TITLE
Register fonts on-demand

### DIFF
--- a/Sources/RswiftResources/Integrations/FontResource+Integrations.swift
+++ b/Sources/RswiftResources/Integrations/FontResource+Integrations.swift
@@ -51,7 +51,12 @@ extension FontResource {
      */
     //    @available(*, deprecated, message: "Use UIFont(resource:size:) initializer instead")
     public func callAsFunction(size: CGFloat) -> UIFont? {
-        UIFont(name: name, size: size)
+        UIFont(resource: self, size: size)
+    }
+    
+    fileprivate func register() {
+        let url = bundle.url(forResource: filename, withExtension: nil)!
+        CTFontManagerRegisterFontsForURL(url as CFURL, .process, nil)
     }
 }
 
@@ -65,6 +70,9 @@ public extension UIFont {
      - returns: A font object of the specified font resource and size.
      */
     convenience init?(resource: FontResource, size: CGFloat) {
+        if !resource.canBeLoaded() {
+          resource.register()
+        }
         self.init(name: resource.name, size: size)
     }
 }


### PR DESCRIPTION
The whole idea of this change is to make https://developer.apple.com/documentation/uikit/text_display_and_fonts/adding_a_custom_font_to_your_app completely obsolete. Having the font part of the “UIAppFonts” value in Info.plist breaks the whole purpose of R.Swift (runtime vs compile-time behaviour) and is very error-prone

R.Swift does provide a `R.validate()` runtime validation to counter this problem. This is unfortunately a runtime only approach.

This change simply register the font on-demand. Note that it continuously calls FontResource.canBeLoaded considering it as cheap (which is the case based on my experience) but we could keep some state somewhere if necessary.