### PR TITLE
Fix unable to build using Xcode Cloud

### DIFF
--- a/Sources/rswift/RswiftCore.swift
+++ b/Sources/rswift/RswiftCore.swift
@@ -328,5 +328,5 @@ public struct RswiftCore {
 private func writeIfChanged(contents: String, toURL outputURL: URL) throws {
     let currentFileContents = try? String(contentsOf: outputURL, encoding: .utf8)
     guard currentFileContents != contents else { return }
-    try contents.write(to: outputURL, atomically: true, encoding: .utf8)
+    try contents.write(to: outputURL, atomically: false, encoding: .utf8)
 }


### PR DESCRIPTION
Fixes https://github.com/mac-cain13/R.swift/issues/862

The RswiftCore implementation can be found at [`try contents.write(to: outputURL, atomically: true, encoding: .utf8)`](https://github.com/mac-cain13/R.swift/blob/a76220f2c4b73bdda670f4a318c6ec983399ac6d/Sources/rswift/RswiftCore.swift#L331C6-L331C6) is used to write the generated code; if `atomically` is `true`, the content is written to an intermediate file and then moved to the outputURL. However, XocdeCloud does not seem to allow writing outside of the pluginWorkDirectory, even for temporary files created by the Foundation framework.

The easiest way to make Build succeed on Xcode Cloud seems to be to change "`atomically`" to `false`.

What do you think about changing it?

References
https://github.com/liamnichols/xcstrings-tool/pull/36

https://zenn.dev/hiragram/articles/49f178b58a36bc
(Written in Japanese)

