### PR TITLE
Fix memory leak caused by NSLocalizedString

### DIFF
--- a/Sources/RswiftResources/Integrations/StringResource+Integrations.swift
+++ b/Sources/RswiftResources/Integrations/StringResource+Integrations.swift
@@ -12,12 +12,20 @@ extension String {
         switch source {
         case let .hosting(bundle):
             // With fallback to developmentValue
-            let format = NSLocalizedString(key.description, tableName: tableName, bundle: bundle, value: developmentValue ?? "", comment: "")
+            let format = if #available(macOS 12, iOS 15, tvOS 15, watchOS 8, *) {
+                String(localized: .init(key.description), table: tableName, bundle: bundle, comment: "")
+            } else {
+                NSLocalizedString(key.description, tableName: tableName, bundle: bundle, value: developmentValue ?? "", comment: "")
+            }
             self = String(format: format, locale: overrideLocale ?? Locale.current, arguments: arguments)
 
         case let .selected(bundle, locale):
             // Don't use developmentValue with selected bundle/locale
-            let format = NSLocalizedString(key.description, tableName: tableName, bundle: bundle, value: "", comment: "")
+            let format = if #available(macOS 12, iOS 15, tvOS 15, watchOS 8, *) {
+                String(localized: .init(key.description), table: tableName, bundle: bundle, comment: "")
+            } else {
+                NSLocalizedString(key.description, tableName: tableName, bundle: bundle, value: developmentValue ?? "", comment: "")
+            }
             self = String(format: format, locale: overrideLocale ?? locale, arguments: arguments)
 
         case .none:


### PR DESCRIPTION
I detected very high memory usage on some screens of my app. I investigated the problem and found that the problem is `NSLocalizedString(_:tableName:bundle:value:comment:)` calls on R.swift. 

This PR replaces `NSLocalizedString(_:tableName:bundle:value:comment:)` calls with `String.init(localized:table:bundle:locale:comment:)` on supported platforms.

# Benchmarks

## Steps
* On Xcode 15.3, create a new iOS app (Storyboard/Swift)
* Created `MyStrings.string` Strings File (Legacy)
* Edited content of `MyStrings.string` to `my_key = "My Text";`
* Edited content of `ViewController.swift` to code below.
* Integrated R.swift with SPM according to documentation
* Modified comments on `ViewController.swift` and SPM package repo/commit to enable different scenarios
* Run the simulator on iPhone 15 iOS 17.4 simulator until timers stopped (30 seconds)
* Noted the high memory usage on Memory Report

```swift
import UIKit

class ViewController: UIViewController {
    private let label: UILabel = .init()

    private var timer: Timer?
    private var stopTimer: Timer?

    override func viewDidLoad() {
        super.viewDidLoad()
        label.translatesAutoresizingMaskIntoConstraints = false
        view.addSubview(label)
        label.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
        label.centerYAnchor.constraint(equalTo: view.centerYAnchor).isActive = true

        timer = .scheduledTimer(withTimeInterval: 0.001, repeats: true, block: { [weak self] _ in
            let date = Date.now.ISO8601Format(.init(includingFractionalSeconds: true))
                        
            //let myValue = R.string.myStrings.my_key()
            
            //let myValue = NSLocalizedString("my_key", tableName: "MyStrings", comment: "")
            
            let myValue = String(localized: .init("my_key"), table: "MyStrings")
           
            self?.label.text = myValue + ": " + date
        })
        stopTimer = .scheduledTimer(withTimeInterval: 30, repeats: false, block: { [weak self] _ in
            self?.timer?.invalidate()
        })
    }
}
```

## Results
*  `NSLocalizedString(_:tableName:bundle:value:comment:)` 
    High is 52.5 MB. It was rising steadily until the timer is stopped.
   
* `String.init(localized:table:bundle:locale:comment:)` 
   High is 30.5 MB.  It was 30 MB from the start to the end.
   
* `R.string.myStrings.my_key()` for `mac-cain13/R.swift master 8d26021c6c71a513505e722f2cc82a6ad4f7f087`
    High is 57.3 MB. It was rising steadily until the timer is stopped.

* `R.string.myStrings.my_key()` for `fthdgn/R.swift nslocalizedstring-memory-leak 9f8f893d35f1d21e64abb8d991243099e3d5cdf0`
    High is 30.4 MB.  It was around 30 MB from the start to the end.