### PR TITLE
Added the ability to specify options, or default arguments, for plugin invocations

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,8 +23,9 @@ let package = Package(
     ],
     targets: [
         .target(name: "RswiftResources"),
+        .target(name: "RswiftShared"),
         .target(name: "RswiftGenerators", dependencies: ["RswiftResources"]),
-        .target(name: "RswiftParsers", dependencies: ["RswiftResources", "XcodeEdit"]),
+        .target(name: "RswiftParsers", dependencies: ["RswiftResources", "RswiftShared", "XcodeEdit"]),
 
         .testTarget(name: "RswiftGeneratorsTests", dependencies: ["RswiftGenerators"]),
         .testTarget(name: "RswiftParsersTests", dependencies: ["RswiftParsers"]),
@@ -33,6 +34,7 @@ let package = Package(
         .executableTarget(name: "rswift", dependencies: [
             .target(name: "RswiftParsers"),
             .target(name: "RswiftGenerators"),
+            .target(name: "RswiftShared"),
             .product(name: "ArgumentParser", package: "swift-argument-parser"),
         ]),
 

--- a/Plugins/RswiftGenerateInternalResources/RswiftGenerateInternalResources.swift
+++ b/Plugins/RswiftGenerateInternalResources/RswiftGenerateInternalResources.swift
@@ -13,33 +13,56 @@ struct RswiftGenerateInternalResources: BuildToolPlugin {
     func createBuildCommands(context: PluginContext, target: Target) async throws -> [Command] {
         guard let target = target as? SourceModuleTarget else { return [] }
 
-        let outputDirectoryPath = context.pluginWorkDirectory
-            .appending(subpath: target.name)
+        let defaultOutputDirectoryPath = context.pluginWorkDirectory.appending(subpath: target.name)
+        let rswiftPath = defaultOutputDirectoryPath.appending(subpath: "R.generated.swift")
 
-        try FileManager.default.createDirectory(atPath: outputDirectoryPath.string, withIntermediateDirectories: true)
+        let optionsFile = URL(fileURLWithPath: target.directory.appending(subpath: ".rswiftoptions").string)
 
-        let rswiftPath = outputDirectoryPath.appending(subpath: "R.generated.swift")
+        // Our base set of options contains only an access level of `internal` given that
+        // this is the "internal" resources plugin, hence the access level should always be
+        // `internal`.
+        let options = RswiftOptions(accessLevel: .internalLevel)
 
-        let sourceFiles = target.sourceFiles
+            // Next we load and merge any options that may be present in an options file. These
+            // options don't override any of the previous options provided, but supplements
+            // those options.
+            .merging(with: try .init(contentsOf: optionsFile))
+
+            // Lastly, we provide a fallback bundle source and output file to ensure that these
+            // values are always set should no other values be provided
+            .merging(with: .init(bundleSource: target.kind == .generic ? .module : .finder,
+                                 outputPath: rswiftPath.string))
+
+        // Get a concrete reference to the file we'll be writing out to
+        let outputPath = options.outputPath.map { $0.hasPrefix("/") ? Path($0) : defaultOutputDirectoryPath.appending(subpath: $0) } ?? rswiftPath
+
+        // Create the output directory, if needed
+        try FileManager.default.createDirectory(atPath: outputPath.removingLastComponent().string,
+                                                withIntermediateDirectories: true)
+
+        // Get the input files for the current target being processed
+        let sourceFiles: [String] = target.sourceFiles
             .filter { $0.type == .resource || $0.type == .unknown }
             .map(\.path.string)
 
-        let inputFilesArguments = sourceFiles
+        let inputFilesArguments: [String] = sourceFiles
             .flatMap { ["--input-files", $0 ] }
 
-        let bundleSource = target.kind == .generic ? "module" : "finder"
-        let description = "\(target.kind) module \(target.name)"
+        // Lastly, convert the options struct into an array of arguments, subsequently
+        // appending the input type and files, all of which will be provided to the
+        // `rswift` utility that we'll invoke.
+        let arguments: [String] =
+            options.makeArguments(sourceDirectory: URL(fileURLWithPath: target.directory.string),
+                                  outputDirectory: URL(fileURLWithPath: outputPath.removingLastComponent().string)) +
+            ["--input-type", "input-files"] + inputFilesArguments
 
+        // Return the build command to execute
         return [
             .buildCommand(
-                displayName: "R.swift generate resources for \(description)",
+                displayName: "R.swift generate resources for \(target.kind) module \(target.name)",
                 executable: try context.tool(named: "rswift").path,
-                arguments: [
-                    "generate", rswiftPath.string,
-                    "--input-type", "input-files",
-                    "--bundle-source", bundleSource,
-                ] + inputFilesArguments,
-                outputFiles: [rswiftPath]
+                arguments: arguments,
+                outputFiles: [outputPath]
             ),
         ]
     }
@@ -51,13 +74,50 @@ import XcodeProjectPlugin
 extension RswiftGenerateInternalResources: XcodeBuildToolPlugin {
     func createBuildCommands(context: XcodePluginContext, target: XcodeTarget) throws -> [Command] {
 
-        let resourcesDirectoryPath = context.pluginWorkDirectory
+        let defaultOutputDirectoryPath = context.pluginWorkDirectory
             .appending(subpath: target.displayName)
             .appending(subpath: "Resources")
 
-        try FileManager.default.createDirectory(atPath: resourcesDirectoryPath.string, withIntermediateDirectories: true)
+        let rswiftPath = defaultOutputDirectoryPath.appending(subpath: "R.generated.swift")
 
-        let rswiftPath = resourcesDirectoryPath.appending(subpath: "R.generated.swift")
+        let projectOptionsFile = URL(fileURLWithPath: context.xcodeProject.directory.appending(subpath: ".rswiftoptions").string)
+        let targetOptionsFile = URL(fileURLWithPath: context.xcodeProject.directory.appending(subpath: target.displayName).appending(subpath: ".rswiftoptions").string)
+
+        // Our base set of options contains an access level of `internal` given that this
+        // is the "internal" resources plugin, hence the access level should always be
+        // `internal`, as well as the bundle source, which is always `finder` for Xcode
+        // projects.
+        let options = RswiftOptions(accessLevel: .internalLevel,
+                                    bundleSource: .finder)
+
+            // Next we load and merge any options that may be present in an options file
+            // specific to the target being processed. These options don't override any of the
+            // previous options provided, but supplements those options.
+            .merging(with: try .init(contentsOf: targetOptionsFile))
+
+            // Next we load and merge any options that may be present in an options file that
+            // applies to the entire project. These options don't override any of the previous
+            // options provided, but supplements those options.
+            .merging(with: try .init(contentsOf: projectOptionsFile))
+
+            // Lastly, we provide a fallback bundle source and output file to ensure that these
+            // values are always set should no other values be provided
+            .merging(with: .init(outputPath: rswiftPath.string))
+
+        // Get a concrete reference to the file we'll be writing out to
+        let outputPath = options.outputPath.map { $0.hasPrefix("/") ? Path($0) : defaultOutputDirectoryPath.appending(subpath: $0) } ?? rswiftPath
+
+        // Create the output directory, if needed
+        try FileManager.default.createDirectory(atPath: outputPath.removingLastComponent().string,
+                                                withIntermediateDirectories: true)
+
+        // Lastly, convert the options struct into an array of arguments, subsequently
+        // appending the input type and files, all of which will be provided to the
+        // `rswift` utility that we'll invoke.
+        let arguments: [String] =
+            options.makeArguments(sourceDirectory: URL(fileURLWithPath: context.xcodeProject.directory.string),
+                                  outputDirectory: URL(fileURLWithPath: outputPath.removingLastComponent().string)) +
+            ["--input-type", "xcodeproj"]
 
         let description: String
         if let product = target.product {
@@ -66,17 +126,13 @@ extension RswiftGenerateInternalResources: XcodeBuildToolPlugin {
             description = target.displayName
         }
 
+        // Return the build command to execute
         return [
             .buildCommand(
                 displayName: "R.swift generate resources for \(description)",
                 executable: try context.tool(named: "rswift").path,
-                arguments: [
-                    "generate", rswiftPath.string,
-                    "--target", target.displayName,
-                    "--input-type", "xcodeproj",
-                    "--bundle-source", "finder",
-                ],
-                outputFiles: [rswiftPath]
+                arguments: arguments,
+                outputFiles: [outputPath]
             ),
         ]
     }

--- a/Plugins/RswiftGenerateInternalResources/RswiftShared
+++ b/Plugins/RswiftGenerateInternalResources/RswiftShared
@@ -1,0 +1,1 @@
+../../Sources/RswiftShared

--- a/Plugins/RswiftGeneratePublicResources/RswiftGeneratePublicResources.swift
+++ b/Plugins/RswiftGeneratePublicResources/RswiftGeneratePublicResources.swift
@@ -13,34 +13,56 @@ struct RswiftGeneratePublicResources: BuildToolPlugin {
     func createBuildCommands(context: PluginContext, target: Target) async throws -> [Command] {
         guard let target = target as? SourceModuleTarget else { return [] }
 
-        let outputDirectoryPath = context.pluginWorkDirectory
-            .appending(subpath: target.name)
+        let defaultOutputDirectoryPath = context.pluginWorkDirectory.appending(subpath: target.name)
+        let rswiftPath = defaultOutputDirectoryPath.appending(subpath: "R.generated.swift")
 
-        try FileManager.default.createDirectory(atPath: outputDirectoryPath.string, withIntermediateDirectories: true)
+        let optionsFile = URL(fileURLWithPath: target.directory.appending(subpath: ".rswiftoptions").string)
 
-        let rswiftPath = outputDirectoryPath.appending(subpath: "R.generated.swift")
+        // Our base set of options contains only an access level of `public` given that
+        // this is the "public" resources plugin, hence the access level should always be
+        // `public`.
+        let options = RswiftOptions(accessLevel: .publicLevel)
 
-        let sourceFiles = target.sourceFiles
+            // Next we load and merge any options that may be present in an options file. These
+            // options don't override any of the previous options provided, but supplements
+            // those options.
+            .merging(with: try .init(contentsOf: optionsFile))
+
+            // Lastly, we provide a fallback bundle source and output file to ensure that these
+            // values are always set should no other values be provided
+            .merging(with: .init(bundleSource: target.kind == .generic ? .module : .finder,
+                                 outputPath: rswiftPath.string))
+
+        // Get a concrete reference to the file we'll be writing out to
+        let outputPath = options.outputPath.map { $0.hasPrefix("/") ? Path($0) : defaultOutputDirectoryPath.appending(subpath: $0) } ?? rswiftPath
+
+        // Create the output directory, if needed
+        try FileManager.default.createDirectory(atPath: outputPath.removingLastComponent().string,
+                                                withIntermediateDirectories: true)
+
+        // Get the input files for the current target being processed
+        let sourceFiles: [String] = target.sourceFiles
             .filter { $0.type == .resource || $0.type == .unknown }
             .map(\.path.string)
 
-        let inputFilesArguments = sourceFiles
+        let inputFilesArguments: [String] = sourceFiles
             .flatMap { ["--input-files", $0 ] }
 
-        let bundleSource = target.kind == .generic ? "module" : "finder"
-        let description = "\(target.kind) module \(target.name)"
+        // Lastly, convert the options struct into an array of arguments, subsequently
+        // appending the input type and files, all of which will be provided to the
+        // `rswift` utility that we'll invoke.
+        let arguments: [String] =
+            options.makeArguments(sourceDirectory: URL(fileURLWithPath: target.directory.string),
+                                  outputDirectory: URL(fileURLWithPath: outputPath.removingLastComponent().string)) +
+            ["--input-type", "input-files"] + inputFilesArguments
 
+        // Return the build command to execute
         return [
             .buildCommand(
-                displayName: "R.swift generate resources for \(description)",
+                displayName: "R.swift generate resources for \(target.kind) module \(target.name)",
                 executable: try context.tool(named: "rswift").path,
-                arguments: [
-                    "generate", rswiftPath.string,
-                    "--input-type", "input-files",
-                    "--bundle-source", bundleSource,
-                    "--access-level", "public",
-                ] + inputFilesArguments,
-                outputFiles: [rswiftPath]
+                arguments: arguments,
+                outputFiles: [outputPath]
             ),
         ]
     }
@@ -52,13 +74,49 @@ import XcodeProjectPlugin
 extension RswiftGeneratePublicResources: XcodeBuildToolPlugin {
     func createBuildCommands(context: XcodePluginContext, target: XcodeTarget) throws -> [Command] {
 
-        let resourcesDirectoryPath = context.pluginWorkDirectory
+        let defaultOutputDirectoryPath = context.pluginWorkDirectory
             .appending(subpath: target.displayName)
             .appending(subpath: "Resources")
 
-        try FileManager.default.createDirectory(atPath: resourcesDirectoryPath.string, withIntermediateDirectories: true)
+        let rswiftPath = defaultOutputDirectoryPath.appending(subpath: "R.generated.swift")
 
-        let rswiftPath = resourcesDirectoryPath.appending(subpath: "R.generated.swift")
+        let projectOptionsFile = URL(fileURLWithPath: context.xcodeProject.directory.appending(subpath: ".rswiftoptions").string)
+        let targetOptionsFile = URL(fileURLWithPath: context.xcodeProject.directory.appending(subpath: target.displayName).appending(subpath: ".rswiftoptions").string)
+
+        // Our base set of options contains an access level of `public` given that this is
+        // the "public" resources plugin, hence the access level should always be `public`,
+        // as well as the bundle source, which is always `finder` for Xcode projects.
+        let options = RswiftOptions(accessLevel: .publicLevel,
+                                    bundleSource: .finder)
+
+            // Next we load and merge any options that may be present in an options file
+            // specific to the target being processed. These options don't override any of the
+            // previous options provided, but supplements those options.
+            .merging(with: try .init(contentsOf: targetOptionsFile))
+
+            // Next we load and merge any options that may be present in an options file that
+            // applies to the entire project. These options don't override any of the previous
+            // options provided, but supplements those options.
+            .merging(with: try .init(contentsOf: projectOptionsFile))
+
+            // Lastly, we provide a fallback bundle source and output file to ensure that these
+            // values are always set should no other values be provided
+            .merging(with: .init(outputPath: rswiftPath.string))
+
+        // Get a concrete reference to the file we'll be writing out to
+        let outputPath = options.outputPath.map { $0.hasPrefix("/") ? Path($0) : defaultOutputDirectoryPath.appending(subpath: $0) } ?? rswiftPath
+
+        // Create the output directory, if needed
+        try FileManager.default.createDirectory(atPath: outputPath.removingLastComponent().string,
+                                                withIntermediateDirectories: true)
+
+        // Lastly, convert the options struct into an array of arguments, subsequently
+        // appending the input type and files, all of which will be provided to the
+        // `rswift` utility that we'll invoke.
+        let arguments: [String] =
+            options.makeArguments(sourceDirectory: URL(fileURLWithPath: context.xcodeProject.directory.string),
+                                  outputDirectory: URL(fileURLWithPath: outputPath.removingLastComponent().string)) +
+            ["--input-type", "xcodeproj"]
 
         let description: String
         if let product = target.product {
@@ -67,18 +125,13 @@ extension RswiftGeneratePublicResources: XcodeBuildToolPlugin {
             description = target.displayName
         }
 
+        // Return the build command to execute
         return [
             .buildCommand(
                 displayName: "R.swift generate resources for \(description)",
                 executable: try context.tool(named: "rswift").path,
-                arguments: [
-                    "generate", rswiftPath.string,
-                    "--target", target.displayName,
-                    "--input-type", "xcodeproj",
-                    "--bundle-source", "finder",
-                    "--access-level", "public",
-                ],
-                outputFiles: [rswiftPath]
+                arguments: arguments,
+                outputFiles: [outputPath]
             ),
         ]
     }

--- a/Plugins/RswiftGeneratePublicResources/RswiftShared
+++ b/Plugins/RswiftGeneratePublicResources/RswiftShared
@@ -1,0 +1,1 @@
+../../Sources/RswiftShared

--- a/Plugins/RswiftGenerateResourcesCommand/RswiftShared
+++ b/Plugins/RswiftGenerateResourcesCommand/RswiftShared
@@ -1,0 +1,1 @@
+../../Sources/RswiftShared

--- a/Sources/RswiftParsers/ProjectResources.swift
+++ b/Sources/RswiftParsers/ProjectResources.swift
@@ -8,23 +8,7 @@
 import Foundation
 import XcodeEdit
 import RswiftResources
-
-public enum ResourceType: String, CaseIterable {
-    case image
-    case string
-    case color
-    case data
-    case file
-    case font
-    case nib
-    case segue
-    case storyboard
-    case reuseIdentifier
-    case entitlements
-    case info
-    case id
-    case project
-}
+import RswiftShared
 
 public struct ProjectResources {
     public let assetCatalogs: [AssetCatalog]

--- a/Sources/RswiftShared/AccessLevel.swift
+++ b/Sources/RswiftShared/AccessLevel.swift
@@ -1,0 +1,13 @@
+//
+//  AccessLevel.swift
+//  R.swift
+//
+//  Created by Joe Newton on 2024-07-11.
+//
+
+public enum AccessLevel: String, Decodable {
+    case publicLevel = "public"
+    case internalLevel = "internal"
+    case filePrivate = "fileprivate"
+    case privateLevel = "private"
+}

--- a/Sources/RswiftShared/BundleSource.swift
+++ b/Sources/RswiftShared/BundleSource.swift
@@ -1,0 +1,11 @@
+//
+//  BundleSource.swift
+//  R.swift
+//
+//  Created by Joe Newton on 2024-07-11.
+//
+
+public enum BundleSource: String, Decodable {
+    case module
+    case finder
+}

--- a/Sources/RswiftShared/ResourceType.swift
+++ b/Sources/RswiftShared/ResourceType.swift
@@ -1,0 +1,23 @@
+//
+//  ResourceType.swift
+//  R.swift
+//
+//  Created by Joe Newton on 2024-07-11.
+//
+
+public enum ResourceType: String, CaseIterable, Decodable {
+    case image
+    case string
+    case color
+    case data
+    case file
+    case font
+    case nib
+    case segue
+    case storyboard
+    case reuseIdentifier
+    case entitlements
+    case info
+    case id
+    case project
+}

--- a/Sources/RswiftShared/RswiftOptions.swift
+++ b/Sources/RswiftShared/RswiftOptions.swift
@@ -1,0 +1,132 @@
+//
+//  RswiftOptions.swift
+//  R.swift
+//
+//  Created by Joe Newton on 2024-07-11.
+//
+
+import Foundation
+
+struct RswiftOptions: Decodable {
+    let generators: [ResourceType]?
+    let omitMainLet: Bool?
+    let imports: [String]?
+    let accessLevel: AccessLevel?
+    let rswiftignore: String?
+    let bundleSource: BundleSource?
+    let outputPath: String?
+    let additionalArguments: [String]?
+
+    init?(contentsOf url: URL) throws {
+        guard FileManager.default.fileExists(atPath: url.path) else { return nil }
+        self = try JSONDecoder().decode(RswiftOptions.self, from: Data(contentsOf: url))
+    }
+
+    init(from arguments: [String]) throws {
+        var structuredArguments: [String: Any] = [:]
+
+        // We first iterate over all of the provided arguments to put them into a
+        // dictionary structure.
+        var i = arguments.startIndex
+        while i < arguments.endIndex {
+            let argument = arguments[i]
+            if argument == "--omit-main-let" {
+                structuredArguments["omit-main-let"] = true
+            } else if argument.hasPrefix("--") {
+                if arguments.index(after: i) == arguments.endIndex {
+                    // This is the very last argument provided
+                    structuredArguments["additional-arguments"] = (structuredArguments["additional-arguments"] as? [String] ?? []) + [argument]
+                } else {
+                    // We have at least one argument that comes after this one
+                    let key = argument == "--import" ? "imports" : String(argument.dropFirst(2))
+                    i = arguments.index(after: i) // Move the index to the argument's value
+
+                    if key == "imports" || key == "generators" {
+                        // These keys represent arrays, so we'll append to that array
+                        structuredArguments[key] = (structuredArguments[key] as? [String] ?? []) + [arguments[i]]
+                    } else {
+                        structuredArguments[key] = arguments[i]
+                    }
+                }
+            } else {
+                structuredArguments["additional-arguments"] = (structuredArguments["additional-arguments"] as? [String] ?? []) + [argument]
+            }
+
+            i = arguments.index(after: i)
+        }
+
+        if structuredArguments.isEmpty {
+            // No options parsed out, simply delegate to the default initializer
+            self.init()
+        } else {
+            // Now that we have a dictionary structure, we can attempt to serialize the
+            // dictionary into data that we can then attempt to decode.
+            let encodedArguments = try JSONSerialization.data(withJSONObject: structuredArguments)
+            self = try JSONDecoder().decode(RswiftOptions.self, from: encodedArguments)
+        }
+    }
+
+    init(generators: [ResourceType]? = nil,
+         omitMainLet: Bool? = nil,
+         imports: [String]? = nil,
+         accessLevel: AccessLevel? = nil,
+         rswiftignore: String? = nil,
+         bundleSource: BundleSource? = nil,
+         outputPath: String? = nil,
+         additionalArguments: [String]? = nil) {
+        self.generators = generators
+        self.omitMainLet = omitMainLet
+        self.imports = imports
+        self.accessLevel = accessLevel
+        self.rswiftignore = rswiftignore
+        self.bundleSource = bundleSource
+        self.outputPath = outputPath
+        self.additionalArguments = additionalArguments
+    }
+
+    func merging(with options: RswiftOptions?) -> RswiftOptions {
+        guard let options else { return self }
+        return RswiftOptions(
+            generators: generators.flatMap { $0.isEmpty ? nil : $0 } ?? options.generators,
+            omitMainLet: omitMainLet ?? options.omitMainLet,
+            imports: imports.flatMap { $0.isEmpty ? nil : $0 } ?? options.imports,
+            accessLevel: accessLevel ?? options.accessLevel,
+            rswiftignore: rswiftignore ?? options.rswiftignore,
+            bundleSource: bundleSource ?? options.bundleSource,
+            outputPath: outputPath ?? options.outputPath,
+            additionalArguments: additionalArguments.map { $0 + (options.additionalArguments ?? []) } ?? options.additionalArguments
+        )
+    }
+
+    func makeArguments(command: String = "generate",
+                       sourceDirectory: URL,
+                       outputDirectory: URL? = nil,
+                       fallbackOutputPath: String = "R.generated.swift") -> [String] {
+        let outputDirectory = outputDirectory ?? sourceDirectory
+        let outputPath = outputPath ?? fallbackOutputPath
+        var arguments: [String] = [
+            command, outputPath.hasPrefix("/") ? outputPath : outputDirectory.appendingPathComponent(outputPath).path
+        ]
+
+        arguments += (generators ?? []).flatMap { ["--generators", $0.rawValue] }
+        arguments += omitMainLet == true ? ["--omit-main-let"] : []
+        arguments += (imports ?? []).flatMap { ["--import", $0] }
+        arguments += accessLevel.map { ["--access-level", $0.rawValue] } ?? []
+        arguments += rswiftignore.map { ["--rswiftignore", $0.starts(with: "/") ? $0 : sourceDirectory.appendingPathComponent($0).path] } ?? []
+        arguments += bundleSource.map { ["--bundle-source", $0.rawValue] } ?? []
+        arguments += additionalArguments ?? []
+
+        return arguments
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case generators
+        case omitMainLet = "omit-main-let"
+        case imports
+        case accessLevel = "access-level"
+        case rswiftignore
+        case bundleSource = "bundle-source"
+        case outputPath = "output-path"
+        case additionalArguments = "additional-arguments"
+    }
+}

--- a/Sources/rswift/App.swift
+++ b/Sources/rswift/App.swift
@@ -8,8 +8,8 @@
 import ArgumentParser
 import Foundation
 import RswiftParsers
+import RswiftShared
 import XcodeEdit
-
 
 @main
 struct App: ParsableCommand {
@@ -211,3 +211,7 @@ extension ProcessInfo {
         return value
     }
 }
+
+extension ResourceType: ExpressibleByArgument {}
+extension AccessLevel: ExpressibleByArgument {}
+extension BundleSource: ExpressibleByArgument {}

--- a/Sources/rswift/RswiftCore.swift
+++ b/Sources/rswift/RswiftCore.swift
@@ -11,20 +11,7 @@ import XcodeEdit
 import RswiftParsers
 import RswiftResources
 import RswiftGenerators
-
-extension ResourceType: ExpressibleByArgument {}
-
-public enum AccessLevel: String, ExpressibleByArgument {
-    case publicLevel = "public"
-    case internalLevel = "internal"
-    case filePrivate = "fileprivate"
-    case privateLevel = "private"
-}
-
-public enum BundleSource: String, ExpressibleByArgument {
-    case module
-    case finder
-}
+import RswiftShared
 
 public struct RswiftCore {
     let outputURL: URL


### PR DESCRIPTION
## What does this PR do?

This PR fills in a gap that is currently present when using the Package/Xcode Plugins to perform source code generation, either manually using the `RswiftGenerateResourcesCommand`, or automatically using the `RswiftGeneratePublicResources` or `RswiftGenerateInternalResources` plugins. The gap to which I speak is that if any customization is needed, i.e. `rswift` arguments, that can _only_ be done when manually running the `RswiftGenerateResourcesCommand` plugin and the arguments must be specified _each_ time the plugin is used.

This is obviously not an ideal scenario, so this PR seeks to alleviate this issue by adding support for an "options" file. The way in which this works is slightly different for Xcode Plugins vs. SPM Plugins, but the premise and formatting is the same:

1. A `.rswiftoptions` file is declared in your sources root (Xcode Plugins can create an additional file in the root of the project as well)
2. When either of the plugins mentioned above the options are loaded from this options file, validated, and then combined with any defaults and options provided via the plugin invocation and including those in the options provided to the `rswift` utility. 
3. That's it!

The `.rswiftoptions` file is a JSON file that has a very simple schema:

```json
{
  "generators": ["..."],
  "omit-main-let": true/false,
  "imports": ["..."],
  "access-level": "public"/"internal",
  "rswiftignore": "...",
  "bundle-source": "finder"/"module",
  "output-path": "...",
  "additional-arguments": ["..."]
}
```

All of the fields in this JSON object are optional and are applied in a systemic and deterministic way when executing the plugins:

1. Create an options structure any arguments passed in from the plugin invocation parsed out. Options provided to the plugin invocation _always_ take precedent since they have to be passed in for each execution, indicating that the intent is to override any preset or default values.
2. (For Xcode Plugins) Attempt to load a `.rswiftoptions` file that is located in the same directory as the project file invoking the plugin. These options are combined with the options in the previous step in such a way to where the previous options will not be overridden by the new options, should a particular option already be set.
3. Attempt to load a `.rswiftoptions` file that is located in the root directory containing the source files for the given target. These options are combined with the options in the previous step in such a way to where the previous options will not be overridden by the new options, should a particular option already be set.
4. Lastly, apply any "fallback" options, i.e. options that should be used should the options not be specified by any other means.

When done in this manner, this allows for one to use these options files to specify the arguments that should always be provided, but allows for those values to be overridden if invoking the plugin directly.

## How are these changes implemented?

The way in which the implementation is done is multifaceted:

1. First, a new library target was created called `RswiftShared` to contain code that should be shared between the `rswift` executable target as well as the plugin targets. The `AccessLevel`, `BundleSource`, and `ResourceType` types were all moved into this new target.
2. Next, symbolic links were created in the plugin sources directories to reference the `RswiftShared` sources directory. This is done to get around an issue where plugin targets cannot have a dependency on a library target so the sources are brought into each of the plugin targets via this symbolic link.
3. An additional type was created to mimic the structure of the JSON options file with a conformance to `Decodable` for easy parsing.
4. Lastly, the implementation of each plugin was updated to attempt to load these `.rswiftoptions` files and combine these options with any provided from the plugin invocation, if relevant.

## Any testing done?

Yes, testing was performed locally using an Xcode project and a Swift Package, each of which was tested by using various combinations of the aforementioned plugins, options files, and options provided when manually invoking the `RswiftGenerateResourcesCommand`. All results of this testing align with the deterministic manner in which those options should have been applied, as described above 