### PR TITLE
Dependency conflicts

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -3,7 +3,7 @@
     {
       "identity" : "swift-argument-parser",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-argument-parser",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
       "state" : {
         "revision" : "8f4d2753f0e4778c76d5f05ad16c74f707390531",
         "version" : "1.2.3"
@@ -12,7 +12,7 @@
     {
       "identity" : "xcodeedit",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/tomlokhorst/XcodeEdit",
+      "location" : "https://github.com/tomlokhorst/XcodeEdit.git",
       "state" : {
         "revision" : "017d23f71fa8d025989610db26d548c44cacefae",
         "version" : "2.10.2"


### PR DESCRIPTION
We're running into some dependency conflicts because the URLs in the `Package.resolved` file do not have the standard `.git` suffix.

If another dependency requests `https://github.com/apple/swift-argument-parser.git` then Xcode cannot resolve the `swift-argument-parser` library for either dependency.

By adding the `.git` suffix the dependency issue is fixed. 

Version: Xcode 16.0
Swift: Swift: 5.9
Platform: iOS 16

