### PR TITLE
Accept optional [preferredLanguages]

### DIFF
--- a/Examples/LocalizedStringApp/LocalizedStringAppTests/LocalizedStringAppTests.swift
+++ b/Examples/LocalizedStringApp/LocalizedStringAppTests/LocalizedStringAppTests.swift
@@ -208,6 +208,12 @@ class LocalizedStringAppTests: XCTestCase {
       R.string.ten.ten1(things: 1),
       String(format: NSLocalizedString("ten1", tableName: "ten", comment: ""), 1)
     )
+
+    /* default preferred language */
+    XCTAssertEqual(
+      R.string(preferredLanguages: nil).one.one1(),
+      NSLocalizedString("one1", tableName: "one", comment: "")
+    )
   }
 
 

--- a/Sources/RswiftGenerators/StringsTable+Generator.swift
+++ b/Sources/RswiftGenerators/StringsTable+Generator.swift
@@ -47,7 +47,7 @@ extension Struct {
             deploymentTarget: deploymentTarget,
             name: SwiftIdentifier(name: name),
             params: [
-                .init(name: "preferredLanguages", localName: nil, typeReference: .init(module: .stdLib, rawName: "[String]"), defaultValue: nil),
+                .init(name: "preferredLanguages", localName: nil, typeReference: .init(module: .stdLib, rawName: "[String]?"), defaultValue: "nil"),
                 .init(name: "locale", localName: nil, typeReference: .init(module: .stdLib, rawName: "Locale?"), defaultValue: "nil")
             ],
             returnType: TypeReference(module: .host, rawName: self.name.value),


### PR DESCRIPTION
Hi. I've been happily using R.swift for a long time now, so I missed the whole 6.x version and now I am migrating from the version 5 to the version 7. Everything seems to be really smooth (thanks!) except one little thing: previously `preferredLanguages` parameter did accept `nil`, so I can pass it down my call chain if I want to, and now I can no longer do that. Funny enough, it seems every part of R.swift still accepts `preferredLanguages: nil` just fine, except the very top autogenerated file. Here is the PR to fix that. 

One note: I could not locate where the tests of those are located, I can only see the example app, which doesn't really test anything, so I am kinda confused here. 