### PR TITLE
Support for Xcode String Catalogs

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -95,6 +95,26 @@ jobs:
     - name: Test
       run: xcodebuild -project Examples/LocalizedStringApp/LocalizedStringApp.xcodeproj -scheme LocalizedStringApp -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.0' test
 
+  test-iOS-StringCatalogApp:
+    runs-on: self-hosted
+    needs: build-rswift
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Download build
+      uses: actions/download-artifact@v4.1.7
+      with:
+        name: rswift-dev
+        path: rswift-dev
+    - name: Put build into place
+      run: |
+        mkdir -p .build/release
+        mv rswift-dev/rswift .build/release/rswift
+        chmod +x .build/release/rswift
+    - name: Test
+      run: xcodebuild -project Examples/StringCatalogApp/StringCatalogApp.xcodeproj -scheme StringCatalogApp -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.0' test
+    
+
   test-tvOS:
     runs-on: self-hosted
     needs: build-rswift

--- a/Documentation/Examples.md
+++ b/Documentation/Examples.md
@@ -99,7 +99,7 @@ let progress = String(format: NSLocalizedString("copy.progress", comment: ""), l
 
 *With R.swift*
 ```swift
-// Localized strings are grouped per table (.strings file)
+// Localized strings are grouped per table (.strings file or .xcstrings file)
 let welcomeMessage = R.string.localizable.welcomeMessage()
 let settingsTitle = R.string.settings.title()
 

--- a/Examples/StringCatalogApp/StringCatalogApp.xcodeproj/project.pbxproj
+++ b/Examples/StringCatalogApp/StringCatalogApp.xcodeproj/project.pbxproj
@@ -1,0 +1,484 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 77;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		D53A5BB52D550AFA005A44F3 /* RswiftLibrary in Frameworks */ = {isa = PBXBuildFile; productRef = D53A5BB42D550AFA005A44F3 /* RswiftLibrary */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		D53A5B7B2D550938005A44F3 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D53A5B5C2D550936005A44F3 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = D53A5B632D550936005A44F3;
+			remoteInfo = StringCatalogApp;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		D53A5B642D550936005A44F3 /* StringCatalogApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = StringCatalogApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		D53A5B7A2D550938005A44F3 /* StringCatalogAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = StringCatalogAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		E2E5836E291D3AB5006E17D9 /* R.swift */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = R.swift; path = ../..; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		D53A5B662D550936005A44F3 /* StringCatalogApp */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = StringCatalogApp;
+			sourceTree = "<group>";
+		};
+		D53A5B7D2D550938005A44F3 /* StringCatalogAppTests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = StringCatalogAppTests;
+			sourceTree = "<group>";
+		};
+/* End PBXFileSystemSynchronizedRootGroup section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		D53A5B612D550936005A44F3 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D53A5BB52D550AFA005A44F3 /* RswiftLibrary in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D53A5B772D550938005A44F3 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		D53A5B5B2D550936005A44F3 = {
+			isa = PBXGroup;
+			children = (
+				E2E5836D291D3AB5006E17D9 /* Packages */,
+				D53A5B662D550936005A44F3 /* StringCatalogApp */,
+				D53A5B7D2D550938005A44F3 /* StringCatalogAppTests */,
+				D53A5B652D550936005A44F3 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		D53A5B652D550936005A44F3 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				D53A5B642D550936005A44F3 /* StringCatalogApp.app */,
+				D53A5B7A2D550938005A44F3 /* StringCatalogAppTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		E2E5836D291D3AB5006E17D9 /* Packages */ = {
+			isa = PBXGroup;
+			children = (
+				E2E5836E291D3AB5006E17D9 /* R.swift */,
+			);
+			name = Packages;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		D53A5B632D550936005A44F3 /* StringCatalogApp */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D53A5B8D2D550938005A44F3 /* Build configuration list for PBXNativeTarget "StringCatalogApp" */;
+			buildPhases = (
+				D53A5B602D550936005A44F3 /* Sources */,
+				D53A5B612D550936005A44F3 /* Frameworks */,
+				D53A5B622D550936005A44F3 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				D53A5BAD2D550A6D005A44F3 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				D53A5B662D550936005A44F3 /* StringCatalogApp */,
+			);
+			name = StringCatalogApp;
+			packageProductDependencies = (
+				D53A5BB42D550AFA005A44F3 /* RswiftLibrary */,
+			);
+			productName = StringCatalogApp;
+			productReference = D53A5B642D550936005A44F3 /* StringCatalogApp.app */;
+			productType = "com.apple.product-type.application";
+		};
+		D53A5B792D550938005A44F3 /* StringCatalogAppTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D53A5B922D550938005A44F3 /* Build configuration list for PBXNativeTarget "StringCatalogAppTests" */;
+			buildPhases = (
+				D53A5B762D550938005A44F3 /* Sources */,
+				D53A5B772D550938005A44F3 /* Frameworks */,
+				D53A5B782D550938005A44F3 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				D53A5B7C2D550938005A44F3 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				D53A5B7D2D550938005A44F3 /* StringCatalogAppTests */,
+			);
+			name = StringCatalogAppTests;
+			packageProductDependencies = (
+			);
+			productName = StringCatalogAppTests;
+			productReference = D53A5B7A2D550938005A44F3 /* StringCatalogAppTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		D53A5B5C2D550936005A44F3 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1620;
+				LastUpgradeCheck = 1620;
+				TargetAttributes = {
+					D53A5B632D550936005A44F3 = {
+						CreatedOnToolsVersion = 16.2;
+					};
+					D53A5B792D550938005A44F3 = {
+						CreatedOnToolsVersion = 16.2;
+						TestTargetID = D53A5B632D550936005A44F3;
+					};
+				};
+			};
+			buildConfigurationList = D53A5B5F2D550936005A44F3 /* Build configuration list for PBXProject "StringCatalogApp" */;
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+				nl,
+			);
+			mainGroup = D53A5B5B2D550936005A44F3;
+			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				D53A5BB32D550AFA005A44F3 /* XCLocalSwiftPackageReference "../../../R.swift" */,
+			);
+			preferredProjectObjectVersion = 77;
+			productRefGroup = D53A5B652D550936005A44F3 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				D53A5B632D550936005A44F3 /* StringCatalogApp */,
+				D53A5B792D550938005A44F3 /* StringCatalogAppTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		D53A5B622D550936005A44F3 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D53A5B782D550938005A44F3 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		D53A5B602D550936005A44F3 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D53A5B762D550938005A44F3 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		D53A5B7C2D550938005A44F3 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = D53A5B632D550936005A44F3 /* StringCatalogApp */;
+			targetProxy = D53A5B7B2D550938005A44F3 /* PBXContainerItemProxy */;
+		};
+		D53A5BAD2D550A6D005A44F3 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			productRef = D53A5BAC2D550A6D005A44F3 /* RswiftGenerateInternalResources */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		D53A5B8E2D550938005A44F3 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = nl.mathijskadijk.StringCatalogApp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		D53A5B8F2D550938005A44F3 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = nl.mathijskadijk.StringCatalogApp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		D53A5B902D550938005A44F3 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		D53A5B912D550938005A44F3 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		D53A5B932D550938005A44F3 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = nl.mathijskadijk.StringCatalogAppTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/StringCatalogApp.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/StringCatalogApp";
+			};
+			name = Debug;
+		};
+		D53A5B942D550938005A44F3 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = nl.mathijskadijk.StringCatalogAppTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/StringCatalogApp.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/StringCatalogApp";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		D53A5B5F2D550936005A44F3 /* Build configuration list for PBXProject "StringCatalogApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D53A5B902D550938005A44F3 /* Debug */,
+				D53A5B912D550938005A44F3 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		D53A5B8D2D550938005A44F3 /* Build configuration list for PBXNativeTarget "StringCatalogApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D53A5B8E2D550938005A44F3 /* Debug */,
+				D53A5B8F2D550938005A44F3 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		D53A5B922D550938005A44F3 /* Build configuration list for PBXNativeTarget "StringCatalogAppTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D53A5B932D550938005A44F3 /* Debug */,
+				D53A5B942D550938005A44F3 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCLocalSwiftPackageReference section */
+		D53A5BB32D550AFA005A44F3 /* XCLocalSwiftPackageReference "../../../R.swift" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = ../../../R.swift;
+		};
+/* End XCLocalSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		D53A5BAC2D550A6D005A44F3 /* RswiftGenerateInternalResources */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = "plugin:RswiftGenerateInternalResources";
+		};
+		D53A5BB42D550AFA005A44F3 /* RswiftLibrary */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = RswiftLibrary;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = D53A5B5C2D550936005A44F3 /* Project object */;
+}

--- a/Examples/StringCatalogApp/StringCatalogApp.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Examples/StringCatalogApp/StringCatalogApp.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Examples/StringCatalogApp/StringCatalogApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/StringCatalogApp/StringCatalogApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser",
       "state" : {
-        "revision" : "fddd1c00396eed152c45a46bea9f47b98e59301d",
-        "version" : "1.2.0"
+        "revision" : "41982a3656a71c768319979febd796c6fd111d5c",
+        "version" : "1.5.0"
       }
     },
     {

--- a/Examples/StringCatalogApp/StringCatalogApp.xcodeproj/xcshareddata/xcschemes/StringCatalogApp.xcscheme
+++ b/Examples/StringCatalogApp/StringCatalogApp.xcodeproj/xcshareddata/xcschemes/StringCatalogApp.xcscheme
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1620"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D53A5B632D550936005A44F3"
+               BuildableName = "StringCatalogApp.app"
+               BlueprintName = "StringCatalogApp"
+               ReferencedContainer = "container:StringCatalogApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D53A5B792D550938005A44F3"
+               BuildableName = "StringCatalogAppTests.xctest"
+               BlueprintName = "StringCatalogAppTests"
+               ReferencedContainer = "container:StringCatalogApp.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D53A5B632D550936005A44F3"
+            BuildableName = "StringCatalogApp.app"
+            BlueprintName = "StringCatalogApp"
+            ReferencedContainer = "container:StringCatalogApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D53A5B632D550936005A44F3"
+            BuildableName = "StringCatalogApp.app"
+            BlueprintName = "StringCatalogApp"
+            ReferencedContainer = "container:StringCatalogApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Examples/StringCatalogApp/StringCatalogApp/AppDelegate.swift
+++ b/Examples/StringCatalogApp/StringCatalogApp/AppDelegate.swift
@@ -1,0 +1,19 @@
+//
+//  AppDelegate.swift
+//  StringCatalogApp
+//
+//  Created by Mathijs Bernson on 06/02/2025.
+//
+
+import UIKit
+
+@main
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        
+        return true
+    }
+
+}
+

--- a/Examples/StringCatalogApp/StringCatalogApp/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Examples/StringCatalogApp/StringCatalogApp/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Examples/StringCatalogApp/StringCatalogApp/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Examples/StringCatalogApp/StringCatalogApp/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,35 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "tinted"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Examples/StringCatalogApp/StringCatalogApp/Assets.xcassets/Contents.json
+++ b/Examples/StringCatalogApp/StringCatalogApp/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Examples/StringCatalogApp/StringCatalogApp/Basic.xcstrings
+++ b/Examples/StringCatalogApp/StringCatalogApp/Basic.xcstrings
@@ -1,0 +1,24 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+    "hello.world" : {
+      "comment" : "A greeting",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hello World"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hallo Wereld"
+          }
+        }
+      }
+    }
+  },
+  "version" : "1.0"
+}

--- a/Examples/StringCatalogApp/StringCatalogApp/Full.xcstrings
+++ b/Examples/StringCatalogApp/StringCatalogApp/Full.xcstrings
@@ -1,0 +1,147 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+    "automatic" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Automatic"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Automatisch"
+          }
+        }
+      }
+    },
+    "goodbye-world" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Dag Wereld"
+          }
+        }
+      }
+    },
+    "hello-world" : {
+      "comment" : "A greeting",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hello World"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hallo Wereld"
+          }
+        }
+      }
+    },
+    "name" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mathijs"
+          }
+        }
+      },
+      "shouldTranslate" : false
+    },
+    "number_of_things" : {
+      "comment" : "The amount of things",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "%d thing"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%d things"
+                }
+              }
+            }
+          }
+        },
+        "nl" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%d ding"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%d dingen"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "proceed_label" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "variations" : {
+            "device" : {
+              "iphone" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Proceed on your iPhone"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Proceed on your device"
+                }
+              }
+            }
+          }
+        },
+        "nl" : {
+          "variations" : {
+            "device" : {
+              "iphone" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "Ga verder op je iPhone"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "Ga verder op je apparaat"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "version" : "1.0"
+}

--- a/Examples/StringCatalogApp/StringCatalogAppTests/StringCatalogAppTests.swift
+++ b/Examples/StringCatalogApp/StringCatalogAppTests/StringCatalogAppTests.swift
@@ -1,0 +1,35 @@
+//
+//  StringCatalogAppTests.swift
+//  StringCatalogAppTests
+//
+//  Created by Mathijs Bernson on 06/02/2025.
+//
+
+import Foundation
+import Testing
+@testable import StringCatalogApp
+
+struct StringCatalogAppTests {
+
+    @Test func testBasicStringCatalog() {
+        #expect(R.string.basic.helloWorld() ==
+                String(localized: "hello.world", table: "Basic"))
+    }
+
+    @Test func testFullStringCatalog() {
+        #expect(R.string.full.automatic() ==
+                String(localized: "automatic", table: "Full"))
+
+        // String with plural based on one parameter (%d)
+        #expect(R.string.full.number_of_things(1) == "1 thing")
+        #expect(R.string.full.number_of_things(2) == "2 things")
+        #expect(R.string.full.number_of_things(1) ==
+                String(format: String(localized: "number_of_things", table: "Full"), 1))
+        #expect(R.string.full.number_of_things(3) ==
+                String(format: String(localized: "number_of_things", table: "Full"), 3))
+
+        // String varied by device
+        #expect(R.string.full.proceed_label() == "Proceed on your iPhone")
+    }
+
+}

--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,7 @@ let package = Package(
         .target(name: "RswiftParsers", dependencies: ["RswiftResources", "XcodeEdit"]),
 
         .testTarget(name: "RswiftGeneratorsTests", dependencies: ["RswiftGenerators"]),
-        .testTarget(name: "RswiftParsersTests", dependencies: ["RswiftParsers"]),
+        .testTarget(name: "RswiftParsersTests", dependencies: ["RswiftParsers"], resources: [.copy("TestData")]),
 
         // Executable that brings all previous parts together
         .executableTarget(name: "rswift", dependencies: [

--- a/Sources/RswiftParsers/Resources/StringsTable+Parser.swift
+++ b/Sources/RswiftParsers/Resources/StringsTable+Parser.swift
@@ -29,17 +29,20 @@ private func parseStringCatalog(url: URL) throws -> StringsTable {
     let stringCatalog = try decoder.decode(StringCatalog.self, from: data)
     let locale = LocaleReference.language(stringCatalog.sourceLanguage)
     let source = locale.debugDescription(filename: "\(basename).xcstrings")
-    let dictionary = try parseStrings(strings: stringCatalog.strings, source: source)
+    let dictionary = try parseStrings(strings: stringCatalog.strings, source: source, sourceLanguage: stringCatalog.sourceLanguage)
     return StringsTable(filename: basename, locale: locale, dictionary: dictionary)
 }
 
 private func parseStrings(
     strings: [StringCatalog.Key : StringCatalog.Translation],
-    source: String
+    source: String,
+    sourceLanguage: String
 ) throws -> [StringsTable.Key: StringsTable.Value] {
     var dictionary: [StringsTable.Key: StringsTable.Value] = [:]
     for (key, translation) in strings {
-        for (_, localization) in translation.localizations {
+        // Ignore strings that aren't translated in the source language
+        for (language, localization) in translation.localizations where language == sourceLanguage {
+            assert(dictionary[key] == nil, "Should only be set once")
             if let stringUnit = localization.stringUnit {
                 dictionary[key] = try parseStringUnit(key: key, val: stringUnit.value, source: source)
             } else if let variations = localization.variations {

--- a/Sources/RswiftResources/StringCatalog.swift
+++ b/Sources/RswiftResources/StringCatalog.swift
@@ -1,0 +1,55 @@
+//
+//  StringCatalog.swift
+//  Rswift
+//
+//  Created by Mathijs Bernson on 15/01/2025.
+//
+
+import Foundation
+
+public struct StringCatalog: Sendable, Decodable {
+    public let sourceLanguage: String
+    public let strings: [String : Translation]
+
+    enum CodingKeys: CodingKey {
+        case sourceLanguage
+        case strings
+        case version
+    }
+    
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        let version = try container.decode(String.self, forKey: .version)
+        guard version == "1.0" else {
+            throw DecodingError.dataCorruptedError(
+                forKey: .version,
+                in: container,
+                debugDescription: "Unsupported version \(version). Expected version 1.0."
+            )
+        }
+
+        self.sourceLanguage = try container.decode(String.self, forKey: .sourceLanguage)
+        self.strings = try container.decode([String : Translation].self, forKey: .strings)
+    }
+
+    public typealias Key = String
+
+    public struct Translation: Decodable, Sendable {
+        public let localizations: [Key : Localization]
+    }
+    
+    public struct Localization: Decodable, Sendable {
+        public let stringUnit: StringUnit?
+        public let variations: Variations?
+    }
+    
+    public struct StringUnit: Decodable, Sendable {
+        public let value: String
+    }
+
+    public struct Variations: Decodable, Sendable {
+        public let plural: [String : Localization]?
+        public let device: [String : Localization]?
+    }
+}

--- a/Tests/RswiftParsersTests/StringCatalogDecodingTests.swift
+++ b/Tests/RswiftParsersTests/StringCatalogDecodingTests.swift
@@ -1,0 +1,53 @@
+//
+//  StringCatalogDecodingTests.swift
+//  Rswift
+//
+//  Created by Mathijs Bernson on 15/01/2025.
+//
+
+import Foundation
+import Testing
+@testable import RswiftResources
+@testable import RswiftParsers
+
+struct StringCatalogDecodingTests {
+    let decoder = JSONDecoder()
+
+    @Test func testDecodingStringCatalog() throws {
+        let url = try #require(Bundle.module.url(forResource: "StringCatalog", withExtension: "xcstrings", subdirectory: "TestData"))
+        do {
+            let data = try Data(contentsOf: url)
+            let stringCatalog = try decoder.decode(StringCatalog.self, from: data)
+            #expect(stringCatalog.sourceLanguage == "en")
+            #expect(stringCatalog.strings.count == 6)
+
+            // Automatically extracted string
+            let automatic = try #require(stringCatalog.strings["automatic"])
+            #expect(automatic.localizations["en"]?.stringUnit?.value == "Automatic")
+            #expect(automatic.localizations["nl"]?.stringUnit?.value == "Automatisch")
+
+            // Manually managed string
+            let manual = try #require(stringCatalog.strings["goodbye-world"])
+            #expect(manual.localizations["en"]?.stringUnit?.value == nil)
+            #expect(manual.localizations["nl"]?.stringUnit?.value == "Dag Wereld")
+
+            // Untranslatable string
+            let untranslated = try #require(stringCatalog.strings["name"])
+            #expect(untranslated.localizations["nl"]?.stringUnit?.value == "Mathijs")
+
+            // Plural string (vary by plural)
+            let plural = try #require(stringCatalog.strings["number_of_things"])
+            let pluralVariations = try #require(plural.localizations["nl"]?.variations?.plural)
+            #expect(pluralVariations["one"]?.stringUnit?.value == "%d ding")
+            #expect(pluralVariations["other"]?.stringUnit?.value == "%d dingen")
+
+            // Device specific string (vary by device)
+            let device = try #require(stringCatalog.strings["proceed_label"])
+            let deviceVariations = try #require(device.localizations["en"]?.variations?.device)
+            #expect(deviceVariations["iphone"]?.stringUnit?.value == "Proceed on your iPhone")
+            #expect(deviceVariations["other"]?.stringUnit?.value == "Proceed on your device")
+        } catch {
+            Issue.record(error, "String catalog failed to parse")
+        }
+    }
+}

--- a/Tests/RswiftParsersTests/StringCatalogDecodingTests.swift
+++ b/Tests/RswiftParsersTests/StringCatalogDecodingTests.swift
@@ -19,7 +19,7 @@ struct StringCatalogDecodingTests {
             let data = try Data(contentsOf: url)
             let stringCatalog = try decoder.decode(StringCatalog.self, from: data)
             #expect(stringCatalog.sourceLanguage == "en")
-            #expect(stringCatalog.strings.count == 6)
+            #expect(stringCatalog.strings.count == 7)
 
             // Automatically extracted string
             let automatic = try #require(stringCatalog.strings["automatic"])

--- a/Tests/RswiftParsersTests/StringsTableParserTests.swift
+++ b/Tests/RswiftParsersTests/StringsTableParserTests.swift
@@ -1,0 +1,41 @@
+//
+//  StringsTableParserTests.swift
+//  Rswift
+//
+//  Created by Mathijs Bernson on 06/02/2025.
+//
+
+import Foundation
+import Testing
+@testable import RswiftResources
+@testable import RswiftParsers
+
+struct StringsTableParserTests {
+    @Test func testParsingStringsFile() throws {
+        let url = try #require(Bundle.module.url(forResource: "StringsFile", withExtension: "strings", subdirectory: "TestData"))
+        let table = try StringsTable.parse(url: url)
+        #expect(table.locale == .none)
+
+        let hello = try #require(table.dictionary["hello-world"])
+        #expect(hello.originalValue == "Hello World")
+        #expect(hello.params.count == 0)
+
+        let things = try #require(table.dictionary["number_of_things"])
+        #expect(things.originalValue == "%d things")
+        #expect(things.params.count == 1)
+        #expect(things.params.first?.name == nil)
+        #expect(things.params.first?.spec == .int)
+    }
+
+    @Test func testParsingStringCatalog() throws {
+        let url = try #require(Bundle.module.url(forResource: "StringCatalog", withExtension: "xcstrings", subdirectory: "TestData"))
+        let table = try StringsTable.parse(url: url)
+        #expect(table.locale == .language("en"))
+
+        let things = try #require(table.dictionary["number_of_things"])
+        #expect(things.originalValue == "%d thing")
+        #expect(things.params.count == 1)
+        #expect(things.params.first?.name == nil)
+        #expect(things.params.first?.spec == .int)
+    }
+}

--- a/Tests/RswiftParsersTests/StringsTableParserTests.swift
+++ b/Tests/RswiftParsersTests/StringsTableParserTests.swift
@@ -32,10 +32,29 @@ struct StringsTableParserTests {
         let table = try StringsTable.parse(url: url)
         #expect(table.locale == .language("en"))
 
+        // Regular string
+        let helloWorld = try #require(table.dictionary["hello-world"])
+        #expect(helloWorld.originalValue == "Hello World")
+
+        // Automatically extracted string
+        let automatic = try #require(table.dictionary["automatic"])
+        #expect(automatic.originalValue == "Automatic")
+
+        // Untranslatable string
+        #expect(table.dictionary["name"] == nil)
+
+        // Plural string (vary by plural)
         let things = try #require(table.dictionary["number_of_things"])
         #expect(things.originalValue == "%d thing")
         #expect(things.params.count == 1)
         #expect(things.params.first?.name == nil)
         #expect(things.params.first?.spec == .int)
+
+        // Device specific string (vary by device)
+        let device = try #require(table.dictionary["proceed_label"])
+        #expect(device.originalValue == "Proceed on your device")
+
+        // String only translated in another language (should be ignored)
+        #expect(table.dictionary["dutch-only"] == nil)
     }
 }

--- a/Tests/RswiftParsersTests/TestData/StringCatalog.xcstrings
+++ b/Tests/RswiftParsersTests/TestData/StringCatalog.xcstrings
@@ -1,0 +1,146 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+    "automatic" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Automatic"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Automatisch"
+          }
+        }
+      }
+    },
+    "goodbye-world" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Dag Wereld"
+          }
+        }
+      }
+    },
+    "hello-world" : {
+      "comment" : "A greeting",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hello World"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hallo Wereld"
+          }
+        }
+      }
+    },
+    "name" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mathijs"
+          }
+        }
+      },
+      "shouldTranslate" : false
+    },
+    "number_of_things" : {
+      "comment" : "The amount of things",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "%d thing"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%d things"
+                }
+              }
+            }
+          }
+        },
+        "nl" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%d ding"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%d dingen"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "proceed_label" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "variations" : {
+            "device" : {
+              "iphone" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Proceed on your iPhone"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Proceed on your device"
+                }
+              }
+            }
+          }
+        },
+        "nl" : {
+          "variations" : {
+            "device" : {
+              "iphone" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "Ga verder op je iPhone"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "Ga verder op je apparaat"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "version" : "1.0"
+}

--- a/Tests/RswiftParsersTests/TestData/StringCatalog.xcstrings
+++ b/Tests/RswiftParsersTests/TestData/StringCatalog.xcstrings
@@ -17,6 +17,18 @@
         }
       }
     },
+    "dutch-only" : {
+      "comment" : "Only translated in Dutch, not explicitly translated in the source language",
+      "extractionState" : "manual",
+      "localizations" : {
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deze vertaling is alleen in het Nederlands"
+          }
+        }
+      }
+    },
     "goodbye-world" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Tests/RswiftParsersTests/TestData/StringsFile.strings
+++ b/Tests/RswiftParsersTests/TestData/StringsFile.strings
@@ -1,0 +1,10 @@
+/* 
+  Localizable.strings
+  Rswift
+
+  Created by Mathijs Bernson on 07/02/2025.
+  
+*/
+
+"hello-world" = "Hello World";
+"number_of_things" = "%d things";


### PR DESCRIPTION
This PR adds support for Xcode String Catalogs to R.swift.

The string catalogs are parsed in a similar fashion to Strings files and Strings Dicts. They output the same type, a StringsTable.

### What's changed in this PR

* Extended `StringsTable+Parser.swift` with support for parsing string catalogs.
* Added unit tests for the StringsTable parser under `RswiftParsersTests`.
* Added a test app `StringCatalogApp` as an integration test. This is also used in the checks workflow on GitHub Actions.

Fixes #840, #861